### PR TITLE
Basic symbolic execution

### DIFF
--- a/hol/p4Syntax.sig
+++ b/hol/p4Syntax.sig
@@ -243,6 +243,8 @@ val scope_ty : hol_type
 
 val status_running_tm : term
 
+val dest_frame : term -> term * term * term
+
 val arch_block_pbl_tm : term
 val dest_arch_block_pbl : term -> term * term
 val is_arch_block_pbl : term -> bool
@@ -262,6 +264,12 @@ val arch_frame_list_regular_tm : term
 val dest_arch_frame_list_regular : term -> term
 val is_arch_frame_list_regular : term -> bool
 val mk_arch_frame_list_regular : term -> term
+
+val dest_actx :
+   term ->
+     term * term * term * term * term * term * term * term * term * term
+val dest_astate : term -> term * term * term * term
+val dest_aenv : term -> term * term * term * term
 
 val dest_e_red : term -> term * term * term * term * term * term
 val e_red_tm : term
@@ -288,6 +296,16 @@ val is_stmt_red : term -> bool
 val mk_stmt_red : term * term * term -> term
 val stmt_red_tm : term
 
+
+val dest_is_e_lval : term -> term
+val is_e_lval_tm : term
+val is_is_e_lval : term -> bool
+val mk_is_e_lval : term -> term
+
+val dest_lookup_funn_sig : term -> term * term * term * term
+val is_lookup_funn_sig : term -> bool
+val lookup_funn_sig_tm : term
+val mk_lookup_funn_sig : term * term * term * term -> term
 
 val dest_assign : term -> term * term * term
 val is_assign : term -> bool

--- a/hol/p4Syntax.sig
+++ b/hol/p4Syntax.sig
@@ -102,6 +102,11 @@ val dest_bitv_unop : term -> term * term
 val is_bitv_unop : term -> bool
 val mk_bitv_unop : term * term -> term
 
+val dest_e_cast : term -> term * term
+val e_cast_tm : term
+val is_e_cast : term -> bool
+val mk_e_cast : term * term -> term
+
 val unop_neg_tm : term
 val unop_compl_tm : term
 val unop_neg_signed_tm : term
@@ -136,6 +141,16 @@ val binop_or_tm : term
 val binop_bin_and_tm : term
 val binop_bin_or_tm : term
 
+val dest_e_concat : term -> term * term
+val e_concat_tm : term
+val is_e_concat : term -> bool
+val mk_e_concat : term * term -> term
+
+val dest_e_slice : term -> term * term * term
+val e_slice_tm : term
+val is_e_slice : term -> bool
+val mk_e_slice : term * term * term -> term
+
 val dest_e_acc : term -> term * term
 val e_acc_tm : term
 val is_e_acc : term -> bool
@@ -147,6 +162,21 @@ val is_e_call : term -> bool
 val mk_e_call : term * term -> term
 
 val mk_e_ext_call_list : string * string * term list -> term
+
+val dest_e_select : term -> term * term * term
+val e_select_tm : term
+val is_e_select : term -> bool
+val mk_e_select : term * term * term -> term
+
+val dest_e_struct : term -> term
+val e_struct_tm : term
+val is_e_struct : term -> bool
+val mk_e_struct : term -> term
+
+val dest_e_header : term -> term * term
+val e_header_tm : term
+val is_e_header : term -> bool
+val mk_e_header : term * term -> term
 
 val stmt_empty_tm : term
 val is_stmt_empty : term -> bool

--- a/hol/p4Syntax.sig
+++ b/hol/p4Syntax.sig
@@ -92,6 +92,11 @@ val is_e_var : term -> bool
 val mk_e_var : term -> term
 val mk_e_var_name : string -> term
 
+val dest_e_list : term -> term
+val e_list_tm : term
+val is_e_list : term -> bool
+val mk_e_list : term -> term
+
 val dest_e_unop : term -> term * term
 val e_unop_tm : term
 val is_e_unop : term -> bool
@@ -191,6 +196,11 @@ val is_stmt_seq : term -> bool
 val mk_stmt_seq : term * term -> term
 val stmt_seq_tm : term
 
+val dest_stmt_trans : term -> term
+val is_stmt_trans : term -> bool
+val mk_stmt_trans : term -> term
+val stmt_trans_tm : term
+
 val dest_stmt_cond : term -> term * term * term
 val is_stmt_cond : term -> bool
 val mk_stmt_cond : term * term * term -> term
@@ -211,12 +221,14 @@ val is_stmt_app : term -> bool
 val mk_stmt_app : term * term -> term
 val stmt_app_tm : term
 
+val stmt_ext_tm : term
+val is_stmt_ext : term -> bool
+
 val mk_stmt_seq_list : term list -> term
 
 val d_ty : hol_type
 
 
-val arch_frame_list_empty_tm : term
 
 val scope_ty : hol_type
 
@@ -233,6 +245,9 @@ val is_pblock_regular : term -> bool
 val mk_pblock_regular :
    term * term * term * term * term -> term
 val pblock_regular_tm : term
+
+val arch_frame_list_empty_tm : term
+val is_arch_frame_list_empty : term -> bool
 
 val arch_frame_list_regular_tm : term
 val dest_arch_frame_list_regular : term -> term

--- a/hol/p4Syntax.sig
+++ b/hol/p4Syntax.sig
@@ -183,6 +183,15 @@ val e_header_tm : term
 val is_e_header : term -> bool
 val mk_e_header : term * term -> term
 
+val d_in_tm : term
+val is_d_in : term -> bool
+val d_out_tm : term
+val is_d_out : term -> bool
+val d_inout_tm : term
+val is_d_inout : term -> bool
+val d_none_tm : term
+val is_d_none : term -> bool
+
 val stmt_empty_tm : term
 val is_stmt_empty : term -> bool
 

--- a/hol/p4Syntax.sml
+++ b/hol/p4Syntax.sml
@@ -161,6 +161,9 @@ val unop_compl_tm = prim_mk_const {Name="unop_compl", Thy="p4"};
 val unop_neg_signed_tm = prim_mk_const {Name="unop_neg_signed", Thy="p4"};
 val unop_un_plus_tm = prim_mk_const {Name="unop_un_plus", Thy="p4"};
 
+val (e_cast_tm,  mk_e_cast, dest_e_cast, is_e_cast) =
+  syntax_fns2 "p4" "e_cast";
+
 val (e_binop_tm,  mk_e_binop, dest_e_binop, is_e_binop) =
   syntax_fns3 "p4"  "e_binop";
 val (bitv_binop_tm, mk_bitv_binop, dest_bitv_binop, is_bitv_binop) =
@@ -184,6 +187,12 @@ val binop_or_tm  = prim_mk_const {Name="binop_or",  Thy="p4"};
 val binop_bin_and_tm = prim_mk_const {Name="binop_bin_and", Thy="p4"};
 val binop_bin_or_tm  = prim_mk_const {Name="binop_bin_or",  Thy="p4"};
 
+val (e_concat_tm,  mk_e_concat, dest_e_concat, is_e_concat) =
+  syntax_fns2 "p4" "e_concat";
+
+val (e_slice_tm,  mk_e_slice, dest_e_slice, is_e_slice) =
+  syntax_fns3 "p4" "e_slice";
+
 val (e_acc_tm, mk_e_acc_tmp, dest_e_acc, is_e_acc) =
   syntax_fns2 "p4" "e_acc";
 val mk_e_acc =
@@ -196,6 +205,15 @@ val mk_e_ext_call_list =
   (fn (objname, metname, l) =>
    (#2 (syntax_fns2 "p4" "e_call")) (mk_funn_ext (objname, metname),
                                      listSyntax.mk_list (l, e_ty)));
+
+val (e_select_tm,  mk_e_select, dest_e_select, is_e_select) =
+  syntax_fns3 "p4" "e_select";
+
+val (e_struct_tm,  mk_e_struct, dest_e_struct, is_e_struct) =
+  syntax_fns1 "p4" "e_struct";
+
+val (e_header_tm,  mk_e_header, dest_e_header, is_e_header) =
+  syntax_fns2 "p4" "e_header";
 
 (*******)
 (* tau *)

--- a/hol/p4Syntax.sml
+++ b/hol/p4Syntax.sml
@@ -53,6 +53,15 @@ fun list_of_novuple (a, b, c, d, e, f, g, h, i) = [a, b, c, d, e, f, g, h, i];
 fun mk_novop tm = HolKernel.list_mk_icomb tm o list_of_novuple;
 val syntax_fns9 = HolKernel.syntax_fns {n = 9, dest = dest_novop, make = mk_novop};
 
+fun dest_decop c e tm =
+   case with_exn strip_comb tm e of
+      (t, [t1, t2, t3, t4, t5, t6, t7, t8, t9, t10]) =>
+         if same_const t c then (t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) else raise e
+    | _ => raise e;
+fun list_of_decuple (a, b, c, d, e, f, g, h, i, j) = [a, b, c, d, e, f, g, h, i, j];
+fun mk_decop tm = HolKernel.list_mk_icomb tm o list_of_decuple;
+val syntax_fns10 = HolKernel.syntax_fns {n = 10, dest = dest_decop, make = mk_decop};
+
 (* TODO: Move to ottSyntax *)
 open ottTheory;
 val (clause_name_tm,  mk_clause_name, dest_clause_name, is_clause_name) =
@@ -152,6 +161,9 @@ val (e_var_tm,  mk_e_var, dest_e_var, is_e_var) =
   syntax_fns1 "p4" "e_var";
 val mk_e_var_name = (#2 (syntax_fns1 "p4" "e_var")) o mk_varn_name o fromMLstring;
 
+val (e_list_tm,  mk_e_list, dest_e_list, is_e_list) =
+  syntax_fns1 "p4" "e_list";
+
 val (e_unop_tm,  mk_e_unop, dest_e_unop, is_e_unop) =
   syntax_fns2 "p4" "e_unop";
 val (bitv_unop_tm, mk_bitv_unop, dest_bitv_unop, is_bitv_unop) =
@@ -215,6 +227,23 @@ val (e_struct_tm,  mk_e_struct, dest_e_struct, is_e_struct) =
 val (e_header_tm,  mk_e_header, dest_e_header, is_e_header) =
   syntax_fns2 "p4" "e_header";
 
+(*****)
+(* d *)
+(*****)
+
+val d_in_tm = prim_mk_const {Name="d_in", Thy="p4"};
+fun is_d_in tm = term_eq tm d_in_tm;
+
+val d_out_tm = prim_mk_const {Name="d_out", Thy="p4"};
+fun is_d_out tm = term_eq tm d_out_tm;
+
+val d_inout_tm = prim_mk_const {Name="d_inout", Thy="p4"};
+fun is_d_inout tm = term_eq tm d_inout_tm;
+
+val d_none_tm = prim_mk_const {Name="d_none", Thy="p4"};
+fun is_d_none tm = term_eq tm d_none_tm;
+
+
 (*******)
 (* tau *)
 (*******)
@@ -254,8 +283,12 @@ val (stmt_block_tm, mk_stmt_block, dest_stmt_block, is_stmt_block) =
   syntax_fns2 "p4"  "stmt_block";
 val (stmt_ret_tm, mk_stmt_ret, dest_stmt_ret, is_stmt_ret) =
   syntax_fns1 "p4"  "stmt_ret";
+val (stmt_trans_tm, mk_stmt_trans, dest_stmt_trans, is_stmt_trans) =
+  syntax_fns1 "p4"  "stmt_trans";
 val (stmt_app_tm, mk_stmt_app, dest_stmt_app, is_stmt_app) =
   syntax_fns2 "p4"  "stmt_app";
+val stmt_ext_tm = prim_mk_const {Name="stmt_ext", Thy="p4"};
+fun is_stmt_ext tm = term_eq tm stmt_ext_tm;
 
 fun mk_stmt_seq_list' (h::[]) = h
   | mk_stmt_seq_list' (h::t) =
@@ -271,8 +304,6 @@ val d_ty = mk_type ("d", []);
 (* State *)
 (*********)
 
-val arch_frame_list_empty_tm = prim_mk_const {Name="arch_frame_list_empty", Thy="p4"};
-
 val scope_ty = mk_list_type $ mk_prod (varn_ty, mk_prod (v_ty, mk_option lval_ty));
 
 val status_running_tm = prim_mk_const {Name="status_running", Thy="p4"};
@@ -284,11 +315,18 @@ val status_running_tm = prim_mk_const {Name="status_running", Thy="p4"};
 val (arch_block_pbl_tm,  mk_arch_block_pbl, dest_arch_block_pbl, is_arch_block_pbl) =
   syntax_fns2 "p4" "arch_block_pbl";
 
+val (arch_block_pbl_tm,  mk_arch_block_pbl, dest_arch_block_pbl, is_arch_block_pbl) =
+  syntax_fns2 "p4" "arch_block_pbl";
+
 val (pblock_regular_tm,  mk_pblock_regular, dest_pblock_regular, is_pblock_regular) =
   syntax_fns5 "p4" "pblock_regular";
 
+val arch_frame_list_empty_tm = prim_mk_const {Name="arch_frame_list_empty", Thy="p4"};
+fun is_arch_frame_list_empty tm = term_eq tm arch_frame_list_empty_tm;
 val (arch_frame_list_regular_tm,  mk_arch_frame_list_regular, dest_arch_frame_list_regular, is_arch_frame_list_regular) =
   syntax_fns1 "p4" "arch_frame_list_regular";
+
+
 
 (**************)
 (* Reductions *)

--- a/hol/p4_auxScript.sml
+++ b/hol/p4_auxScript.sml
@@ -2304,4 +2304,17 @@ Definition p4_append_input_list_def:
        ((ab_index, inputl++[h], outputl, ascope), gscope, afl, status)))
 End
 
+(**************************)
+(* For symbolic execution *)
+
+(* Used for path unification *)
+Theorem IMP_HYP_CASES:
+!A B C.
+(A /\ C ==> B) ==>
+(~A /\ C ==> B) ==>
+C ==> B
+Proof
+metis_tac[]
+QED
+
 val _ = export_theory ();

--- a/hol/p4_testLib.sig
+++ b/hol/p4_testLib.sig
@@ -6,6 +6,10 @@ val mk_ipv4_packet_ok : term -> int -> term
 val mk_ipv4_packet_ok_ttl : term -> int -> term
 val mk_eth_frame_ok : term -> term
 
+val get_actx : thm -> term
+val simple_arith_ss : simpLib.simpset
+val the_final_state_imp : thm -> term
+
 val eval_and_print_result : string -> term -> term -> int -> term
 val eval_and_print_aenv : string -> term -> term -> int -> term
 val eval_and_print_rest : string -> term -> term -> int -> term

--- a/hol/p4_testLib.sml
+++ b/hol/p4_testLib.sml
@@ -189,11 +189,21 @@ fun eval_and_print_rest arch actx astate nsteps =
 
 val simple_arith_ss = pure_ss++numSimps.REDUCE_ss
 
+fun the_final_state_imp step_thm = optionSyntax.dest_some $ snd $ dest_eq $ snd $ dest_imp $ concl step_thm
+
+fun get_actx step_thm =
+ let
+  val step_thm_tm = concl step_thm
+ in
+  #1 $ dest_arch_multi_exec $ fst $ dest_eq $ 
+   (if is_imp step_thm_tm
+    then snd $ dest_imp $ step_thm_tm
+    else step_thm_tm)
+ end
+
 (* TODO: Add debug print output *)
 (* TODO: Make version that executes until packet is output *)
 local
-fun the_final_state_imp step_thm = optionSyntax.dest_some $ snd $ dest_eq $ snd $ dest_imp $ concl step_thm
-
 (* Stepwise evaluation under assumptions *)
 fun eval_under_assum' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm step_thm 0 = step_thm
   | eval_under_assum' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm step_thm fuel =

--- a/hol/symb_exec/Holmakefile
+++ b/hol/symb_exec/Holmakefile
@@ -1,0 +1,52 @@
+# includes
+# ----------------------------------
+DEPENDENCIES   = ..
+
+
+# configuration
+# ----------------------------------
+HOLHEAP        = ../p4-heap
+NEWHOLHEAP     = p4_symbexec-heap
+
+HEAPINC_EXTRA  = wordsLib
+
+
+# included lines follow
+# ----------------------------------
+
+# automatic Holmake targets (all theories and non-"Script.sml" .sml files)
+# automatic heap inclusion by name pattern
+# ----------------------------------
+SMLFILES       = $(subst *.sml,,  $(patsubst %Script.sml,%Theory.sml,$(wildcard *.sml)))
+TARGETS        = $(patsubst %.sml,%.uo,$(SMLFILES))
+
+HEAPINC        = $(subst *Theory,,$(patsubst %Script.sml,%Theory    ,$(wildcard *Script.sml))) \
+                 $(subst *Syntax,,$(patsubst       %.sml,%          ,$(wildcard *Syntax.sml))) \
+                 $(subst *Simps,, $(patsubst       %.sml,%          ,$(wildcard *Simps.sml ))) \
+                 $(subst *Lib,,   $(patsubst       %.sml,%          ,$(wildcard *Lib.sml   ))) \
+                 $(HEAPINC_EXTRA)
+
+
+# general configs
+# ----------------------------------
+all: $(TARGETS) $(if $(NEWHOLHEAP),$(NEWHOLHEAP),)
+
+INCLUDES       = $(DEPENDENCIES) $(if $(HOLHEAP),$(shell dirname $(HOLHEAP)),)
+
+EXTRA_CLEANS   = $(if $(NEWHOLHEAP),$(NEWHOLHEAP) $(NEWHOLHEAP).o,) $(wildcard *.exe)
+
+OPTIONS        = QUIT_ON_FAILURE
+
+default: all
+
+.PHONY: all default
+
+
+# holheap part
+# ----------------------------------
+ifdef POLY
+
+$(NEWHOLHEAP): $(TARGETS) $(HOLHEAP)
+	$(protect $(HOLDIR)/bin/buildheap) $(if $(HOLHEAP),-b $(HOLHEAP),) -o $@ $(HEAPINC)
+
+endif

--- a/hol/symb_exec/p4_symb_execLib.sig
+++ b/hol/symb_exec/p4_symb_execLib.sig
@@ -6,4 +6,8 @@ val symb_exec:
    hol_type ->
      term -> term -> term list -> term list -> thm -> int -> (thm * thm) list
 
+val p4_symb_exec_prove_contract:
+   hol_type ->
+     term -> term -> term list -> term list -> thm -> int -> term -> thm
+
 end

--- a/hol/symb_exec/p4_symb_execLib.sig
+++ b/hol/symb_exec/p4_symb_execLib.sig
@@ -1,0 +1,9 @@
+signature p4_symb_execLib =
+sig
+  include Abbrev
+
+val symb_exec:
+   hol_type ->
+     term -> term -> term list -> term list -> thm -> int -> (thm * thm) list
+
+end

--- a/hol/symb_exec/p4_symb_execLib.sig
+++ b/hol/symb_exec/p4_symb_execLib.sig
@@ -2,9 +2,14 @@ signature p4_symb_execLib =
 sig
   include Abbrev
 
+datatype path_tree = empty | node of int * thm * (path_tree list);
+
 val symb_exec:
    hol_type ->
-     term -> term -> term list -> term list -> thm -> int -> (thm * thm) list
+     term ->
+       term ->
+         term list ->
+           term list -> thm -> int -> path_tree * (int * thm * thm) list
 
 val p4_symb_exec_prove_contract:
    hol_type ->

--- a/hol/symb_exec/p4_symb_execLib.sig
+++ b/hol/symb_exec/p4_symb_execLib.sig
@@ -2,14 +2,12 @@ signature p4_symb_execLib =
 sig
   include Abbrev
 
-datatype path_tree = empty | node of int * thm * (path_tree list);
-
-val symb_exec:
+val p4_symb_exec:
    hol_type ->
      term ->
        term ->
          term list ->
-           term list -> thm -> int -> path_tree * (int * thm * thm) list
+           term list -> thm -> int -> symb_execLib.path_tree * (int * thm * thm) list
 
 val p4_symb_exec_prove_contract:
    hol_type ->

--- a/hol/symb_exec/p4_symb_execLib.sml
+++ b/hol/symb_exec/p4_symb_execLib.sml
@@ -493,8 +493,6 @@ val p4_stop_eval_consts =
 ];
 
 (* Function that decides whether to branch or not *)
-(* TODO: This is a P4-specific function that has been factored out, make it an argument of
- * the generic symb_exec *)
 fun p4_should_branch step_thm =
  let
   val astate = the_final_state_imp step_thm
@@ -584,8 +582,6 @@ fun p4_regular_step ctx stop_consts_rewr stop_consts_never comp_thm (path_cond, 
 ;
 
 (* Function that decides whether we are finished or not *)
-(* TODO: This is a P4-specific function that has been factored out, make it an argument of
- * the generic symb_exec *)
 fun p4_is_finished step_thm =
  let
   val astate = the_final_state_imp step_thm
@@ -600,6 +596,9 @@ fun p4_is_finished step_thm =
  end
 ;
 
+(* Here, the static ctxt and the dynamic path condition have been merged.
+ * Currently, the path condition is stripped down as much as possible from p4-specific stuff
+ * (another design priority could be legibility and keeping the connection to the P4 constructs). *)
 fun p4_symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond fuel =
  let
   val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl

--- a/hol/symb_exec/p4_symb_execLib.sml
+++ b/hol/symb_exec/p4_symb_execLib.sml
@@ -1,223 +1,20 @@
+structure p4_symb_execLib :> p4_symb_execLib = struct
+
 open HolKernel boolLib liteLib simpLib Parse bossLib;
 
-open pairSyntax listSyntax optionSyntax computeLib hurdUtils;
+open pairSyntax listSyntax numSyntax computeLib hurdUtils;
 
 open p4Theory p4_exec_semTheory p4Syntax p4_exec_semSyntax;
 
 open evalwrapLib p4_testLib;
 
-val _ = new_theory "p4_symb_exec";
-(* TODO: Rename "branch condition"? *)
+open optionSyntax;
 
 val ERR = mk_HOL_ERR "p4_symb_exec"
 
-(* Checking if a conditional statement is about to be reduced
- * to one of its two statement constituents *)
-
-
-Definition stmt_get_cond_def:
- stmt_get_cond stmt =
-  case stmt of
-  | stmt_empty => NONE
-  | stmt_ass lval e => NONE
-  | stmt_cond e stmt' stmt'' =>
-   SOME e
-  | stmt_block t_scope stmt' =>
-   stmt_get_cond stmt'
-  | stmt_ret e => NONE
-  | stmt_seq stmt' stmt'' =>
-   stmt_get_cond stmt'
-  | stmt_trans e => NONE
-  | stmt_app x e_l => NONE
-  | stmt_ext => NONE
-End
-(* OLD
-Definition e_get_next_subexp_def:
- (e_get_next_subexp e =
-   case e of
-   | e_v v => NONE
-   | e_var varn => SOME (e_var varn)
-   | e_list e_l =>
-    (case e_l_get_next_subexp e_l of
-     | NONE => SOME (e_list e_l)
-     | SOME e' => SOME e')
-   | e_acc e' x =>
-    (case e_get_next_subexp e' of
-     | NONE => SOME (e_acc e' x)
-     | SOME e'' => SOME e'')
-   | e_unop unop e' =>
-    (case e_get_next_subexp e' of
-     | NONE => SOME (e_unop unop e')
-     | SOME e'' => SOME e'')
-   | e_cast cast e' =>
-    (case e_get_next_subexp e' of
-     | NONE => SOME (e_cast cast e')
-     | SOME e'' => SOME e'')
-   | e_binop e' binop e'' =>
-    (case e_get_next_subexp e' of
-     | NONE =>
-      if is_short_circuitable binop
-      then SOME (e_binop e' binop e'')
-      else
-       (case e_get_next_subexp e'' of
-        | NONE =>
-         SOME (e_binop e' binop e'')
-        | SOME e''' => SOME e''')
-     | SOME e''' => SOME e''')
-   | e_concat e' e'' =>
-    (case e_get_next_subexp e' of
-     | NONE =>
-      (case e_get_next_subexp e'' of
-       | NONE =>
-        SOME (e_concat e' e'')
-       | SOME e''' => SOME e''')
-     | SOME e''' => SOME e''')
-   | e_slice e' e'' e''' =>
-    (case e_get_next_subexp e' of
-     | NONE =>
-      (case e_get_next_subexp e'' of
-       | NONE =>
-        (case e_get_next_subexp e''' of
-         | NONE =>
-          SOME (e_slice e' e'' e''')
-         | SOME e'''' => SOME e'''')
-       | SOME e'''' => SOME e'''')
-     | SOME e'''' => SOME e'''')
-   | e_call funn e_l =>
-    (case e_l_get_next_subexp e_l of
-     | NONE => SOME (e_call funn e_l)
-     | SOME e' => SOME e')
-   | e_select e' v_x_l x =>
-    (case e_get_next_subexp e' of
-     | NONE => SOME (e_select e' v_x_l x)
-     | SOME e'' => SOME e'')
-   | e_struct x_e_l =>
-    (case e_l_get_next_subexp $ (MAP SND) x_e_l of
-     | NONE => SOME (e_struct x_e_l)
-     | SOME e' => SOME e')
-   | e_header boolv x_e_l =>
-    (case e_l_get_next_subexp $ (MAP SND) x_e_l of
-     | NONE => SOME (e_header boolv x_e_l)
-     | SOME e' => SOME e')) /\
- (e_l_get_next_subexp [] = NONE) /\
- (e_l_get_next_subexp (h::t) = 
-  (case e_get_next_subexp h of
-   | NONE => e_l_get_next_subexp t
-   | SOME e' => SOME e'))
-Termination
-cheat
-End
-
-Definition list_get_next_e_def:
- (list_get_next_e [] = NONE) /\
- (list_get_next_e (h::t) = 
-  (case h of
-   | e_v v => list_get_next_e t
-   | e' => SOME e'))
-End
-
-Definition stmt_get_next_e_def:
- stmt_get_next_e stmt =
-  case stmt of
-  | stmt_empty => NONE
-  | stmt_ass lval e => SOME e
-  | stmt_cond e stmt' stmt'' =>
-   SOME e
-  | stmt_block t_scope stmt' =>
-   stmt_get_next_e stmt'
-  | stmt_ret e => SOME e
-  | stmt_seq stmt' stmt'' =>
-   stmt_get_next_e stmt'
-  | stmt_trans e => SOME e
-  | stmt_app x e_l =>
-   list_get_next_e e_l
-  | stmt_ext => NONE
-End
-
-Definition stmt_get_next_e_subexp_def:
- stmt_get_next_e_subexp stmt =
-  case stmt_get_next_e stmt of
-  | SOME e => e_get_next_subexp e
-  | NONE => NONE
-End
-
-(*
-val branch_cond_opt = rhs $ concl $ EVAL “stmt_get_cond (stmt_cond
-               (e_binop (e_v (v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8)))
-                  binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
-               (stmt_ass
-                  (lval_field (lval_varname (varn_name "standard_meta"))
-                     "egress_spec")
-                  (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
-               (stmt_ass
-                  (lval_field (lval_varname (varn_name "standard_meta"))
-                     "egress_spec")
-                  (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9)))))”;
-
-next_e_has_free_vars “(e_binop
-                    (e_acc
-                       (e_v
-                          (v_struct
-                             [("e",v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8));
-                              ("t",
-                               v_bit
-                                 ([F; F; F; T; F; F; F; T; F; F; F; T; F; F;
-                                   F; T],16));
-                              ("l",v_bit ([F; F; F; F; F; F; F; F],8));
-                              ("r",v_bit ([F; F; F; F; F; F; F; F],8));
-                              ("v",v_bit ([T; F; T; T; F; F; F; F],8))])) "e")
-                    binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))”
-
-*)
-*)
-Definition astate_get_top_stmt_def:
- astate_get_top_stmt ((aenv, g_scope_list, arch_frame_list, status):'a astate) =
-  case arch_frame_list of
-  | arch_frame_list_empty => NONE
-  | arch_frame_list_regular frame_list =>
-   (case frame_list of
-    | [] => NONE
-    | ((funn, stmt_stack, scope_list)::t) =>
-     (case stmt_stack of
-      | [] => NONE
-      | (h'::t') => SOME h'
-     )
-   )
-End
-
-Definition astate_get_cond_def:
- astate_get_cond astate =
-  case astate_get_top_stmt astate of
-  | SOME stmt => stmt_get_cond stmt
-  | NONE => NONE
-End
-
-(*
-Definition astate_get_next_e_subexp_def:
- astate_get_next_e_subexp astate =
-  case astate_get_top_stmt astate of
-  | SOME stmt => stmt_get_next_e_subexp stmt
-  | NONE => NONE
-End
-
-Definition astate_get_next_e_def:
- astate_get_next_e astate =
-  case astate_get_top_stmt astate of
-  | SOME stmt => stmt_get_next_e stmt
-  | NONE => NONE
-End
-
-Definition is_cond_red_next_def:
- is_cond_red_next stmt =
-  case stmt_get_cond stmt of
-  | SOME cond => T
-  | NONE => F
-End
-*)
+(* TODO: Rename "branch condition"? Is this terminology OK? *)
 
 (* TODO: The below two are also found in p4_testLib.sml - put elsewhere? *)
-(* TODO: For some reason, step_thm sometimes has an antecedent, sometimes not. Find out
- * what's going on and unify the form. *)
 fun the_final_state_imp step_thm =
  let
   val step_thm_tm = concl step_thm
@@ -240,15 +37,20 @@ fun get_actx step_thm =
  end
 
 (* TODO: Move to syntax library *)
+fun dest_frame frame =
+ case spine_pair frame of
+    [funn, stmt_stack, scope_list] => (funn, stmt_stack, scope_list)
+  | _ => raise (ERR "dest_frame" ("Unsupported frame shape: "^(term_to_string frame)))
+;
 fun dest_actx actx =
  case spine_pair actx of
     [ab_list, pblock_map, ffblock_map, input_f, output_f, copyin_pbl, copyout_pbl, apply_table_f, ext_fun_map, func_map] => (ab_list, pblock_map, ffblock_map, input_f, output_f, copyin_pbl, copyout_pbl, apply_table_f, ext_fun_map, func_map)
-  | _ => raise (ERR "dest_actx" ("Invalid actx shape: "^(term_to_string actx)))
+  | _ => raise (ERR "dest_actx" ("Unsupported actx shape: "^(term_to_string actx)))
 ;
 fun dest_astate astate =
  case spine_pair astate of
     [aenv, g_scope_list, arch_frame_list, status] => (aenv, g_scope_list, arch_frame_list, status)
-  | _ => raise (ERR "dest_astate" ("Invalid astate shape: "^(term_to_string astate)))
+  | _ => raise (ERR "dest_astate" ("Unsupported astate shape: "^(term_to_string astate)))
 ;
 (* TODO: Fix this hack *)
 fun dest_aenv aenv =
@@ -261,20 +63,70 @@ fun dest_aenv aenv =
  end
 ;
 
-(* TODO: Definition a HOL4 function for this for now, would be a pain in the ass otherwise *)
-Definition get_b_func_map_def:
- get_b_func_map i ab_list pblock_map =
-  case EL i ab_list of
-  | (arch_block_pbl f e_l) =>
-   (case ALOOKUP pblock_map f of
-    | SOME (pblock_regular pbl_type b_func_map t_scope pars_map tbl_map) =>
-     SOME b_func_map
-    | NONE => NONE)
-  | _ => NONE
-End
-
 fun get_b_func_map i ab_list pblock_map =
- rhs $ concl $ EVAL “get_b_func_map ^i ^ab_list ^pblock_map”
+ let
+  val arch_block = el ((int_of_term i) + 1) (fst $ dest_list ab_list)
+ in
+  if is_arch_block_pbl arch_block
+  then
+   let
+    val arch_block_name = fst $ dest_arch_block_pbl arch_block
+   in
+    case List.find (fn (name, data) => term_eq name arch_block_name) ((map dest_pair) $ fst $ dest_list pblock_map) of
+      SOME (_, pblock) =>
+     if is_pblock_regular pblock 
+     then SOME $ #2 $ dest_pblock_regular pblock
+     else NONE
+    | NONE => NONE
+   end
+  else NONE
+ end
+;
+
+(* TODO: Rename to stmt_get_substmt? *)
+fun stmt_get_next stmt =
+ if is_stmt_empty stmt
+ then stmt
+ else if is_stmt_ass stmt
+ then stmt
+ else if is_stmt_cond stmt
+ then stmt
+ else if is_stmt_block stmt
+ then stmt_get_next $ snd $ dest_stmt_block stmt
+ else if is_stmt_ret stmt
+ then stmt
+ else if is_stmt_seq stmt
+ then stmt_get_next $ fst $ dest_stmt_seq stmt
+ else if is_stmt_trans stmt
+ then stmt
+ else if is_stmt_app stmt
+ then stmt
+ else if is_stmt_ext stmt
+ then stmt
+ else raise (ERR "stmt_get_next" ("Unsupported statement: "^(term_to_string stmt)))
+;
+
+fun astate_get_top_stmt astate =
+ let
+  val (_, _, arch_frame_list, _) = dest_astate astate
+ in
+  if is_arch_frame_list_empty arch_frame_list
+  then NONE
+  else SOME $ el 1 $ fst $ dest_list $ #2 $ dest_frame $ el 1 $ fst $ dest_list $ dest_arch_frame_list_regular arch_frame_list
+ end
+;
+
+fun astate_get_cond astate =
+ case astate_get_top_stmt astate of
+   SOME stmt =>
+  let
+   val stmt' = stmt_get_next stmt
+  in
+   if is_stmt_cond stmt'
+   then SOME $ #1 $ dest_stmt_cond stmt'
+   else NONE
+  end
+ | NONE => NONE
 ;
 
 (* TODO: This should be done in pre-processing, not at every step *)
@@ -287,9 +139,9 @@ fun get_f_maps step_thm =
   val (i, _, _, _) = dest_aenv aenv
   val b_func_map_opt = get_b_func_map i ab_list pblock_map
  in
-  if is_some b_func_map_opt
-  then (func_map, dest_some b_func_map_opt, ext_fun_map)
-  else (func_map, “[]:b_func_map”, ext_fun_map)
+  case get_b_func_map i ab_list pblock_map of
+    SOME b_func_map => (func_map, b_func_map, ext_fun_map)
+  | NONE => (func_map, “[]:b_func_map”, ext_fun_map)
  end
 ;
 
@@ -312,7 +164,7 @@ fun is_arg_red (arg, dir) =
  else is_e_v arg (* Must be constant *)
 ;
 
-(* TODO: This needs a map between function names and the directions of their parameters *)
+
 fun e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e =
  if is_e_v e
  then NONE
@@ -570,6 +422,7 @@ fun stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt =
  else raise (ERR "stmt_get_next_e_syntax_f" ("Unsupported statement: "^(term_to_string stmt)))
 ;
 
+
 fun get_next_e (func_map, b_func_map, ext_fun_map) stmt =
  case stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt of
    SOME f => SOME (f stmt)
@@ -605,6 +458,7 @@ fun astate_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) astate =
  end
 ;
 
+
 fun astate_get_next_e (func_map, b_func_map, ext_fun_map) astate =
  let
   val (aenv, g_scope_list, arch_frame_list, status) = dest_astate astate
@@ -630,120 +484,6 @@ fun astate_get_next_e (func_map, b_func_map, ext_fun_map) astate =
  end
 ;
 
-(*
-fun next_e_has_free_vars e =
- if is_e_v e
- then not $ null $ free_vars e
- else if is_e_var e
- then false
- else if is_e_list e
- then
-  let
-   val e_list = dest_e_list e
-  in
-   next_e_has_free_vars_list (dest_list e_list)
-  end
- else if is_e_acc e
- then
-  let
-   val (e', x) = dest_e_acc e
-  in
-   (* We can always allow field access to proceed *)
-   if is_e_v e'
-   then false
-   else next_e_has_free_vars e'
-  end
- else if is_e_unop e
- then
-  let
-   val (unop, e') = dest_e_unop e
-  in
-   next_e_has_free_vars e'
-  end
- else if is_e_cast e
- then
-  let
-   val (cast, e') = dest_e_cast e
-  in
-   (* We can always allow cast to proceed *)
-   if is_e_v e'
-   then false
-   else next_e_has_free_vars e'
-  end
- else if is_e_binop e
- then
-  let
-   val (e', binop, e'') = dest_e_binop e
-  in
-   if is_e_v e'
-   then next_e_has_free_vars e'
-   else next_e_has_free_vars e''
-  end
- else if is_e_concat e
- then
-  let
-   val (e', e'') = dest_e_concat e
-  in
-   (* We can always allow concat to proceed *)
-   if is_e_v e'
-   then
-    if is_e_v e''
-    then false
-    else next_e_has_free_vars e''
-   else next_e_has_free_vars e'
-  end
- else if is_e_slice e
- then
-  let
-   val (e', e'', e''') = dest_e_slice e
-  in
-   (* We can allow slice to proceed if indices have no free variables *)
-   if is_e_v e'
-   then
-    if is_e_v e''
-    then
-     if is_e_v e'''
-     then next_e_has_free_vars e'' orelse next_e_has_free_vars e'''
-     else next_e_has_free_vars e'''
-    else next_e_has_free_vars e''
-   else next_e_has_free_vars e'
-  end
- else if is_e_call e
- then
-  let
-   val (funn, e_list) = dest_e_call e
-  in
-   next_e_has_free_vars_list (fst $ dest_list e_list)
-  end
- else if is_e_select e
- then
-  let
-   val (e', v_x_list, x) = dest_e_select e
-  in
-   next_e_has_free_vars e'
-  end
- else if is_e_struct e
- then
-  let
-   val x_e_list = dest_e_struct e
-  in
-   next_e_has_free_vars_list ((map (snd o dest_pair)) $ fst $ dest_list x_e_list)
-  end
- else if is_e_header e
- then
-  let
-   val (boolv, x_e_list) = dest_e_header e
-  in
-   next_e_has_free_vars_list ((map (snd o dest_pair)) $ fst $ dest_list x_e_list)
-  end
- else raise (ERR "next_e_has_free_vars" ("Unsupported expression: "^(term_to_string e)))
-and next_e_has_free_vars_list []     = false
-  | next_e_has_free_vars_list (h::t) =
-   if next_e_has_free_vars h
-   then true
-   else next_e_has_free_vars_list t
-;
-*)
 
 (* Symbolic executor should do similar things as eval_under_assum, but on every iteration
  * check if conditional is next to be reduced, then next_e_has_free_vars.
@@ -767,10 +507,6 @@ and next_e_has_free_vars_list []     = false
  * evaluation when to halt
  * 
  * *)
-
-(* TEST *)
-val branch_cond = “(e_binop (e_v (v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8)))
-                    binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))”;
 
 (* RESTR_EVAL_RULE constants: *)
 val p4_stop_eval_consts =
@@ -797,26 +533,14 @@ val p4_stop_eval_consts =
 (* Function that decides whether to branch or not *)
 (* TODO: This is a P4-specific function that has been factored out, make it an argument of
  * the generic symb_exec *)
-(* TODO: Add more constants to RESTR_EVAL_CONV? *)
 fun p4_should_branch step_thm =
- let
-  val astate = the_final_state_imp step_thm
-  val branch_cond_opt = rhs $ concl $ RESTR_EVAL_CONV p4_stop_eval_consts “astate_get_cond ^astate”
- in
-  if is_some branch_cond_opt
-  then
-   let
-    val branch_cond = dest_some branch_cond_opt
-   in
-    if is_e_v branch_cond andalso not $ null $ free_vars branch_cond
-    then SOME (dest_v_bool $ dest_e_v branch_cond)
-    else NONE
-   end
-  else NONE
- end
+  case astate_get_cond $ the_final_state_imp step_thm of
+    SOME branch_cond =>
+   if is_e_v branch_cond andalso not $ null $ free_vars branch_cond
+   then SOME (dest_v_bool $ dest_e_v branch_cond)
+   else NONE
+  | NONE => NONE
 ;
-
-
 
 fun p4_regular_step ctx stop_consts_rewr stop_consts_never comp_thm (path_cond, step_thm) =
  let
@@ -928,156 +652,4 @@ fun symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_co
  end
 end;
 
-(* Test area *)
-
-val symb_exec1_actx = ``([arch_block_inp;
-  arch_block_pbl "p"
-    [e_var (varn_name "b"); e_var (varn_name "parsedHdr");
-     e_var (varn_name "meta"); e_var (varn_name "standard_metadata")];
-  arch_block_ffbl "postparser";
-  arch_block_pbl "vrfy" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
-  arch_block_pbl "ingress"
-    [e_var (varn_name "hdr"); e_var (varn_name "meta");
-     e_var (varn_name "standard_metadata")];
-  arch_block_pbl "egress"
-    [e_var (varn_name "hdr"); e_var (varn_name "meta");
-     e_var (varn_name "standard_metadata")];
-  arch_block_pbl "update" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
-  arch_block_pbl "deparser" [e_var (varn_name "b"); e_var (varn_name "hdr")];
-  arch_block_out],
- [("p",
-   pblock_regular pbl_type_parser
-     [("p",stmt_seq stmt_empty (stmt_trans (e_v (v_str "start"))),
-       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])] []
-     [("start",
-       stmt_seq
-         (stmt_ass lval_null
-            (e_call (funn_ext "packet_in" "extract")
-               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
-         (stmt_trans (e_v (v_str "accept"))))] []);
-  ("vrfy",
-   pblock_regular pbl_type_control
-     [("vrfy",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
-     [] [] []);
-  ("update",
-   pblock_regular pbl_type_control
-     [("update",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
-     [] [] []);
-  ("egress",
-   pblock_regular pbl_type_control
-     [("egress",stmt_seq stmt_empty stmt_empty,
-       [("h",d_inout); ("m",d_inout); ("sm",d_inout)])] [] [] []);
-  ("deparser",
-   pblock_regular pbl_type_control
-     [("deparser",
-       stmt_seq stmt_empty
-         (stmt_ass lval_null
-            (e_call (funn_ext "packet_out" "emit")
-               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"])),
-       [("b",d_none); ("h",d_in)])] [] [] []);
-  ("ingress",
-   pblock_regular pbl_type_control
-     [("ingress",
-       stmt_seq stmt_empty
-         (stmt_cond
-            (e_binop
-               (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row") "e")
-               binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
-            (stmt_ass
-               (lval_field (lval_varname (varn_name "standard_meta"))
-                  "egress_spec")
-               (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
-            (stmt_ass
-               (lval_field (lval_varname (varn_name "standard_meta"))
-                  "egress_spec")
-               (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9))))),
-       [("h",d_inout); ("m",d_inout); ("standard_meta",d_inout)])] [] [] [])],
- [("postparser",ffblock_ff v1model_postparser)],
- v1model_input_f
-   (v_struct
-      [("h",
-        v_header ARB
-          [("row",
-            v_struct
-              [("e",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
-               ("t",
-                v_bit
-                  ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB;
-                    ARB; ARB; ARB; ARB; ARB],16));
-               ("l",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
-               ("r",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
-               ("v",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8))])])],
-    v_struct []),v1model_output_f,v1model_copyin_pbl,v1model_copyout_pbl,
- v1model_apply_table_f,
- [("header",NONE,
-   [("isValid",[("this",d_in)],header_is_valid);
-    ("setValid",[("this",d_inout)],header_set_valid);
-    ("setInvalid",[("this",d_inout)],header_set_invalid)]);
-  ("",NONE,
-   [("mark_to_drop",[("standard_metadata",d_inout)],v1model_mark_to_drop);
-    ("verify",[("condition",d_in); ("err",d_in)],v1model_verify)]);
-  ("packet_in",NONE,
-   [("extract",[("this",d_in); ("headerLvalue",d_out)],
-     v1model_packet_in_extract);
-    ("lookahead",[("this",d_in); ("targ1",d_in)],v1model_packet_in_lookahead);
-    ("advance",[("this",d_in); ("bits",d_in)],v1model_packet_in_advance)]);
-  ("packet_out",NONE,
-   [("emit",[("this",d_in); ("data",d_in)],v1model_packet_out_emit)]);
-  ("register",
-   SOME
-     ([("this",d_out); ("size",d_none); ("targ1",d_in)],register_construct),
-   [("read",[("this",d_in); ("result",d_out); ("index",d_in)],register_read);
-    ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
- [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
-
-val symb_exec1_astate = rhs $ concl $ EVAL “(p4_append_input_list [([F; F; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
-   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
- ([F; F; F; F; F; F; T; F; F; F; F; T; F; F; F; T; T; F; F; F; F; F; F; T; F;
-   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
- ([T; T; T; T; F; F; T; T; F; F; F; T; F; F; F; F; F; F; F; F; F; F; F; F; F;
-   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
- ([T; T; T; T; F; T; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
-   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
-
-(* eval_under_assum: *)
-GEN_ALL $ eval_under_assum p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate [] [] (ASSUME T) 10;
-
-val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
-   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
-
-(* symb_exec: *)
-(* Parameter assignment for debugging: *)
-val arch_ty = p4_v1modelLib.v1model_arch_ty
-val ctx = symb_exec1_actx
-val init_astate = symb_exec1_astate_symb
-val stop_consts_rewr = []
-val stop_consts_never = []
-val path_cond = (ASSUME T)
-val fuel = 2
-
-val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
-
-val [(path_cond, step_thm)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 24
-
-(* Something goes wrong here *)
-val [(path_cond, step_thm), (path_cond2, step_thm2)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25
-
-val [(path_cond, step_thm), (path_cond2, step_thm2)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 26
-
-
-
-
-symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 13
-
-
-
-
-
-
-
-
-
-val _ = export_theory ();
+end

--- a/hol/symb_exec/p4_symb_execScript.sml
+++ b/hol/symb_exec/p4_symb_execScript.sml
@@ -1,0 +1,385 @@
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open pairSyntax listSyntax optionSyntax;
+
+open p4Theory p4_exec_semTheory p4Syntax p4_exec_semSyntax;
+
+open evalwrapLib p4_testLib;
+
+val _ = new_theory "p4_symb_exec";
+
+val ERR = mk_HOL_ERR "p4_symb_exec"
+
+(* Checking if a conditional statement is about to be reduced
+ * to one of its two statement constituents *)
+
+Definition stmt_get_cond_def:
+ stmt_get_cond stmt =
+  case stmt of
+  | stmt_empty => NONE
+  | stmt_ass lval e => NONE
+  | stmt_cond e stmt' stmt'' =>
+   (case e of
+    | e_v cond => SOME cond
+    | _ => NONE)
+  | stmt_block t_scope stmt' =>
+   stmt_get_cond stmt'
+  | stmt_ret e => NONE
+  | stmt_seq stmt' stmt'' =>
+   stmt_get_cond stmt'
+  | stmt_trans e => NONE
+  | stmt_app x e_l => NONE
+  | stmt_ext => NONE
+End
+
+Definition astate_get_cond_def:
+ astate_get_cond ((aenv, g_scope_list, arch_frame_list, status):'a astate) =
+  case arch_frame_list of
+  | arch_frame_list_empty => NONE
+  | arch_frame_list_regular frame_list =>
+   (case frame_list of
+    | [] => NONE
+    | ((funn, stmt_stack, scope_list)::t) =>
+     (case stmt_stack of
+      | [] => NONE
+      | (h'::t') => stmt_get_cond h'
+     )
+   )
+End
+
+Definition is_cond_red_next_def:
+ is_cond_red_next stmt =
+  case stmt_get_cond stmt of
+  | SOME cond => T
+  | NONE => F
+End
+
+(* Can use the SML function "free_vars" to check if expression to be
+ * reduced contains any free variables. We should probably only perform
+ * a branch if the next smallest subexpression to be reduced includes
+ * a free variable. But even this subexpression reduction should be OK for
+ * certain expressions: for example, bit slicing and casting if all
+ * free variables involved are Booleans. *)
+fun next_e_has_free_vars e =
+ if is_e_v e
+ then not $ null $ free_vars e
+ else if is_e_var e
+ then false
+ else if is_e_acc e
+ then
+  let
+   val (e', x) = dest_e_acc e
+  in
+   (* We can always allow field access to proceed *)
+   if is_e_v e'
+   then false
+   else next_e_has_free_vars e'
+  end
+ else if is_e_unop e
+ then
+  let
+   val (unop, e') = dest_e_unop e
+  in
+   next_e_has_free_vars e'
+  end
+ else if is_e_cast e
+ then
+  let
+   val (cast, e') = dest_e_cast e
+  in
+   (* We can always allow cast to proceed *)
+   if is_e_v e'
+   then false
+   else next_e_has_free_vars e'
+  end
+ else if is_e_binop e
+ then
+  let
+   val (e', binop, e'') = dest_e_binop e
+  in
+   if is_e_v e'
+   then next_e_has_free_vars e'
+   else next_e_has_free_vars e''
+  end
+ else if is_e_concat e
+ then
+  let
+   val (e', e'') = dest_e_concat e
+  in
+   (* We can always allow concat to proceed *)
+   if is_e_v e'
+   then
+    if is_e_v e''
+    then false
+    else next_e_has_free_vars e''
+   else next_e_has_free_vars e'
+  end
+ else if is_e_slice e
+ then
+  let
+   val (e', e'', e''') = dest_e_slice e
+  in
+   (* We can allow slice to proceed if indices have no free variables *)
+   if is_e_v e'
+   then
+    if is_e_v e''
+    then
+     if is_e_v e'''
+     then next_e_has_free_vars e'' orelse next_e_has_free_vars e'''
+     else next_e_has_free_vars e'''
+    else next_e_has_free_vars e''
+   else next_e_has_free_vars e'
+  end
+ else if is_e_call e
+ then
+  let
+   val (funn, e_list) = dest_e_call e
+  in
+   next_e_has_free_vars_list (fst $ dest_list e_list)
+  end
+ else if is_e_select e
+ then
+  let
+   val (e', v_x_list, x) = dest_e_select e
+  in
+   next_e_has_free_vars e'
+  end
+ else if is_e_struct e
+ then
+  let
+   val x_e_list = dest_e_struct e
+  in
+   next_e_has_free_vars_list ((map (snd o dest_pair)) $ fst $ dest_list x_e_list)
+  end
+ else if is_e_header e
+ then
+  let
+   val (boolv, x_e_list) = dest_e_header e
+  in
+   next_e_has_free_vars_list ((map (snd o dest_pair)) $ fst $ dest_list x_e_list)
+  end
+ (* Unsupported: e_list *)
+ else raise (ERR "next_e_has_free_vars" ("Unsupported expression: "^(term_to_string e)))
+and next_e_has_free_vars_list []     = false
+  | next_e_has_free_vars_list (h::t) =
+   if next_e_has_free_vars h
+   then true
+   else next_e_has_free_vars_list t
+;
+
+
+(* Symbolic executor should do similar things as eval_under_assum, but on every iteration
+ * check if conditional is next to be reduced, then next_e_has_free_vars.
+ *
+ * Handler consists of:
+ * get_branch_cond: Function that tells if to perform branch. Returns NONE if no, SOME cond
+ * if yes, where cond is the condition (a term) to branch upon.
+ *
+ * new free variable introduction *)
+
+(* eval_under_assum used like:
+   eval_under_assum v1model_arch_ty ctx init_astate stop_consts_rewr stop_consts_never ctxt nsteps_max;
+ * ctxt is a static evaluation context with theorems to rewrite with (use ASSUME on terms)
+ * stop_consts_rewr and stop_consts_never are used for handling externs - telling the
+ * evaluation when to halt
+ * 
+ * *)
+
+local
+(* TODO: The below two are also found in p4_testLib.sml - put elsewhere? *)
+fun the_final_state_imp step_thm = dest_some $ snd $ dest_eq $ snd $ dest_imp $ concl step_thm
+val simple_arith_ss = pure_ss++numSimps.REDUCE_ss
+
+(* Symbolic execution with branching on if-then-else
+ * Width-first scheduling (positive case first)
+ * Note that branching consumes one step of fuel
+ * Note that the static ctxt is shared between the branches, whereas the dynamic path
+ * conditions are different and not shared *)
+fun symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm [] finished_list =
+ finished_list
+  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm
+               ((path_cond, step_thm, 0)::t) finished_list =
+   symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm t
+              (finished_list@[(path_cond, step_thm)])
+  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm
+               ((path_cond, step_thm, fuel)::t) finished_list =
+ let
+  val curr_state = the_final_state_imp step_thm
+  (* Check if we should branch or take regular step *)
+  (* TODO: Use separate handler for this - factor out the below into a separate function *)
+  val branch_cond_opt = rhs $ concl $ EVAL “astate_get_cond curr_state”
+ in
+  if is_some branch_cond_opt
+  (* Branch + prune *)
+  then
+   let
+    (* Get branch condition term *)
+    val branch_cond = dest_some branch_cond_opt
+    (* Get new rewriting contexts for the positive and negative cases *)
+    val path_cond_cond = CONJ path_cond (ASSUME branch_cond)
+    val path_cond_neg_cond = CONJ path_cond (ASSUME $ mk_neg branch_cond)
+    (* Check if the new rewriting contexts contradict themselves *)
+    val is_path_cond_cond_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_cond)
+    val is_path_cond_neg_cond_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_neg_cond)
+    (* Prune away symbolic states with contradictory path_cond, otherwise add them to
+     * end of procesing queue. Positive case goes before negative. *)
+    val next_astate_cond =
+     if is_path_cond_cond_F then [] else [(path_cond_cond, step_thm, fuel-1)]
+    val next_astate_neg_cond =
+     if is_path_cond_neg_cond_F then [] else [(path_cond_neg_cond, step_thm, fuel-1)]
+   in
+    symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm (t@(next_astate_cond@next_astate_neg_cond)) finished_list
+   end
+  (* Do not branch - compute one step *)
+  else
+   let
+    val step_thm2 =
+     eval_ctxt_gen (stop_consts_rewr@stop_consts_never) stop_consts_never ctxt (mk_arch_multi_exec (ctx, curr_state, 1));
+    val comp_step_thm =
+     SIMP_RULE simple_arith_ss []
+      (MATCH_MP (MATCH_MP comp_thm step_thm) step_thm2);
+   in
+    symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm (t@[(path_cond, comp_step_thm, fuel-1)]) finished_list
+   end
+ end
+
+in
+fun symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never ctxt path_cond fuel =
+ let
+  (* TODO: Also branch check here *)
+  val step_thm =
+   eval_ctxt_gen (stop_consts_rewr@stop_consts_never) stop_consts_never ctxt (mk_arch_multi_exec (ctx, init_astate, 1));
+  val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl;
+ in
+  if fuel = 1
+  then [(path_cond, step_thm)]
+  else symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm [(path_cond, step_thm, (fuel-1))] []
+ end
+end;
+
+(* Test area *)
+
+val symb_exec1_actx = ``([arch_block_inp;
+  arch_block_pbl "p"
+    [e_var (varn_name "b"); e_var (varn_name "parsedHdr");
+     e_var (varn_name "meta"); e_var (varn_name "standard_metadata")];
+  arch_block_ffbl "postparser";
+  arch_block_pbl "vrfy" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "ingress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "egress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "update" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "deparser" [e_var (varn_name "b"); e_var (varn_name "hdr")];
+  arch_block_out],
+ [("p",
+   pblock_regular pbl_type_parser
+     [("p",stmt_seq stmt_empty (stmt_trans (e_v (v_str "start"))),
+       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])] []
+     [("start",
+       stmt_seq
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_in" "extract")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
+         (stmt_trans (e_v (v_str "accept"))))] []);
+  ("vrfy",
+   pblock_regular pbl_type_control
+     [("vrfy",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("update",
+   pblock_regular pbl_type_control
+     [("update",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("egress",
+   pblock_regular pbl_type_control
+     [("egress",stmt_seq stmt_empty stmt_empty,
+       [("h",d_inout); ("m",d_inout); ("sm",d_inout)])] [] [] []);
+  ("deparser",
+   pblock_regular pbl_type_control
+     [("deparser",
+       stmt_seq stmt_empty
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_out" "emit")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"])),
+       [("b",d_none); ("h",d_in)])] [] [] []);
+  ("ingress",
+   pblock_regular pbl_type_control
+     [("ingress",
+       stmt_seq stmt_empty
+         (stmt_cond
+            (e_binop
+               (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row") "e")
+               binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9))))),
+       [("h",d_inout); ("m",d_inout); ("standard_meta",d_inout)])] [] [] [])],
+ [("postparser",ffblock_ff v1model_postparser)],
+ v1model_input_f
+   (v_struct
+      [("h",
+        v_header ARB
+          [("row",
+            v_struct
+              [("e",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("t",
+                v_bit
+                  ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB;
+                    ARB; ARB; ARB; ARB; ARB],16));
+               ("l",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("r",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("v",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8))])])],
+    v_struct []),v1model_output_f,v1model_copyin_pbl,v1model_copyout_pbl,
+ v1model_apply_table_f,
+ [("header",NONE,
+   [("isValid",[("this",d_in)],header_is_valid);
+    ("setValid",[("this",d_inout)],header_set_valid);
+    ("setInvalid",[("this",d_inout)],header_set_invalid)]);
+  ("",NONE,
+   [("mark_to_drop",[("standard_metadata",d_inout)],v1model_mark_to_drop);
+    ("verify",[("condition",d_in); ("err",d_in)],v1model_verify)]);
+  ("packet_in",NONE,
+   [("extract",[("this",d_in); ("headerLvalue",d_out)],
+     v1model_packet_in_extract);
+    ("lookahead",[("this",d_in); ("targ1",d_in)],v1model_packet_in_lookahead);
+    ("advance",[("this",d_in); ("bits",d_in)],v1model_packet_in_advance)]);
+  ("packet_out",NONE,
+   [("emit",[("this",d_in); ("data",d_in)],v1model_packet_out_emit)]);
+  ("register",
+   SOME
+     ([("this",d_out); ("size",d_none); ("targ1",d_in)],register_construct),
+   [("read",[("this",d_in); ("result",d_out); ("index",d_in)],register_read);
+    ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
+ [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
+
+val symb_exec1_astate = rhs $ concl $ EVAL “(p4_append_input_list [([F; F; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([F; F; F; F; F; F; T; F; F; F; F; T; F; F; F; T; T; F; F; F; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([T; T; T; T; F; F; T; T; F; F; F; T; F; F; F; F; F; F; F; F; F; F; F; F; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([T; T; T; T; F; T; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
+
+(* eval_under_assum: *)
+GEN_ALL $ eval_under_assum p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate [] [] (ASSUME T) 10;
+
+val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
+
+(* symb_exec: *)
+symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 23
+
+(* TODO: Something goes wrong here: *)
+symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 24
+
+symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 25
+
+val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_execScript.sml
+++ b/hol/symb_exec/p4_symb_execScript.sml
@@ -1,0 +1,43 @@
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open p4Theory;
+
+val _ = new_theory "p4_symb_exec";
+
+Definition packet_has_port_def:
+ packet_has_port (((i, in_out_list, in_out_list', scope), g_scope_list, arch_frame_list, status):'a astate) port_ok =
+  case in_out_list' of
+    [] => F
+  | [(data, port)] => port = port_ok
+  | _ => F
+End
+
+Definition p4_contract_def:
+ p4_contract P ctx s Q =
+  (P ==> ?n. arch_multi_exec ctx s n <> NONE /\ !s'. arch_multi_exec ctx s n = SOME s' ==> Q s')
+End
+
+Theorem p4_symb_exec_to_contract:
+!P ctx s n s' Q.
+(P ==> arch_multi_exec ctx s n = SOME s' /\ Q s') ==>
+p4_contract P ctx s Q
+Proof
+fs[p4_contract_def] >>
+rpt strip_tac >>
+qexists_tac ‘n’ >>
+rpt strip_tac >> (
+ fs[]
+)
+QED
+
+Theorem p4_symb_exec_unify:
+!P1 P2 ctx s Q.
+p4_contract (P1 /\ P2) ctx s Q ==>
+p4_contract (~P1 /\ P2) ctx s Q ==>
+p4_contract P2 ctx s Q
+Proof
+fs[p4_contract_def] >>
+metis_tac []
+QED
+
+val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_execScript.sml
+++ b/hol/symb_exec/p4_symb_execScript.sml
@@ -1,6 +1,8 @@
 open HolKernel boolLib liteLib simpLib Parse bossLib;
 
-open p4Theory;
+open p4Theory listTheory;
+
+open symb_execTheory;
 
 val _ = new_theory "p4_symb_exec";
 
@@ -17,6 +19,32 @@ Definition p4_contract_def:
   (P ==> ?n. arch_multi_exec ctx s n <> NONE /\ !s'. arch_multi_exec ctx s n = SOME s' ==> Q s')
 End
 
+(* TODO: This can be written using FOLDL *)
+Definition p4_contract_list_def:
+ (p4_contract_list P (h::[]) ctx s Q = p4_contract (P ==> h) ctx s Q) /\
+ (p4_contract_list P (h::t) ctx s Q = (p4_contract (P ==> h) ctx s Q /\ p4_contract_list P t ctx s Q)) /\
+ (p4_contract_list P [] ctx s Q = T)
+End
+
+Theorem p4_contract_list_REWR:
+ !R P P_list ctx s Q b.
+ (((p4_contract (R ==> P) ctx s Q /\ b) /\ p4_contract_list R P_list ctx s Q) <=> (b /\ p4_contract_list R (P::P_list) ctx s Q)) /\
+ ((p4_contract (R ==> P) ctx s Q /\ p4_contract_list R P_list ctx s Q) <=> p4_contract_list R (P::P_list) ctx s Q) /\
+ ((p4_contract (R ==> P) ctx s Q /\ b) <=> (b /\ p4_contract_list R [P] ctx s Q))
+Proof
+Cases_on ‘P_list’ >> (
+ fs[p4_contract_list_def] >>
+ metis_tac[]
+)
+QED
+
+Theorem p4_contract_imp_REWR:
+ !P ctx s Q.
+ ((p4_contract P ctx s Q) <=> (p4_contract (T ==> P) ctx s Q))
+Proof
+fs[p4_contract_def]
+QED
+
 Theorem p4_symb_exec_to_contract:
 !P ctx s n s' Q.
 (P ==> arch_multi_exec ctx s n = SOME s' /\ Q s') ==>
@@ -30,6 +58,8 @@ rpt strip_tac >> (
 )
 QED
 
+(* For branching and unification *)
+
 Theorem p4_symb_exec_unify:
 !P1 P2 ctx s Q.
 p4_contract (P1 /\ P2) ctx s Q ==>
@@ -40,28 +70,25 @@ fs[p4_contract_def] >>
 metis_tac []
 QED
 
-(* For branching and unification *)
-
-(* OLD, with superfluous base case
-Definition list_disj_def:
- (list_disj [] = T) /\
- (list_disj (h::t) = (h \/ list_disj t))
-End
-*)
-(* TODO: What should the base case be? *)
-Definition list_disj_def:
- (list_disj (h::t) =
-  if t = []
-  then h
-  else (h \/ list_disj t))
-End
-
-Definition p4_contract_list_def:
- (p4_contract_list [] P ctx s Q = p4_contract P ctx s Q) /\
- (p4_contract_list (h::t) P ctx s Q =
-  if t = []
-  then p4_contract (h /\ P) ctx s Q
-  else (p4_contract (h /\ P) ctx s Q /\ p4_contract_list t P ctx s Q))
-End
+(* Note that the point with this theorem is to explicitly
+ * incorporate R ==> disj_list P_list ("disj_thm") as a premise,
+ * so you don't need to rewrite or reason using
+ * it when obtaining the conclusion *)
+Theorem p4_symb_exec_unify_n_gen:
+!P_list R P' ctx s Q.
+(R ==> disj_list P_list) ==>
+p4_contract_list R P_list ctx s Q ==>
+p4_contract R ctx s Q
+Proof
+Induct_on ‘P_list’ >> (
+ fs [disj_list_def, p4_contract_list_def, p4_contract_def]
+) >>
+rpt strip_tac >>
+Cases_on ‘P_list’ >> (
+ fs [disj_list_def, p4_contract_list_def, p4_contract_def]
+) >>
+rpt strip_tac >>
+fs[]
+QED
 
 val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_execScript.sml
+++ b/hol/symb_exec/p4_symb_execScript.sml
@@ -40,4 +40,28 @@ fs[p4_contract_def] >>
 metis_tac []
 QED
 
+(* For branching and unification *)
+
+(* OLD, with superfluous base case
+Definition list_disj_def:
+ (list_disj [] = T) /\
+ (list_disj (h::t) = (h \/ list_disj t))
+End
+*)
+(* TODO: What should the base case be? *)
+Definition list_disj_def:
+ (list_disj (h::t) =
+  if t = []
+  then h
+  else (h \/ list_disj t))
+End
+
+Definition p4_contract_list_def:
+ (p4_contract_list [] P ctx s Q = p4_contract P ctx s Q) /\
+ (p4_contract_list (h::t) P ctx s Q =
+  if t = []
+  then p4_contract (h /\ P) ctx s Q
+  else (p4_contract (h /\ P) ctx s Q /\ p4_contract_list t P ctx s Q))
+End
+
 val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_execScript.sml
+++ b/hol/symb_exec/p4_symb_execScript.sml
@@ -1,17 +1,19 @@
 open HolKernel boolLib liteLib simpLib Parse bossLib;
 
-open pairSyntax listSyntax optionSyntax;
+open pairSyntax listSyntax optionSyntax computeLib hurdUtils;
 
 open p4Theory p4_exec_semTheory p4Syntax p4_exec_semSyntax;
 
 open evalwrapLib p4_testLib;
 
 val _ = new_theory "p4_symb_exec";
+(* TODO: Rename "branch condition"? *)
 
 val ERR = mk_HOL_ERR "p4_symb_exec"
 
 (* Checking if a conditional statement is about to be reduced
  * to one of its two statement constituents *)
+
 
 Definition stmt_get_cond_def:
  stmt_get_cond stmt =
@@ -19,9 +21,7 @@ Definition stmt_get_cond_def:
   | stmt_empty => NONE
   | stmt_ass lval e => NONE
   | stmt_cond e stmt' stmt'' =>
-   (case e of
-    | e_v cond => SOME cond
-    | _ => NONE)
+   SOME e
   | stmt_block t_scope stmt' =>
    stmt_get_cond stmt'
   | stmt_ret e => NONE
@@ -31,9 +31,147 @@ Definition stmt_get_cond_def:
   | stmt_app x e_l => NONE
   | stmt_ext => NONE
 End
+(* OLD
+Definition e_get_next_subexp_def:
+ (e_get_next_subexp e =
+   case e of
+   | e_v v => NONE
+   | e_var varn => SOME (e_var varn)
+   | e_list e_l =>
+    (case e_l_get_next_subexp e_l of
+     | NONE => SOME (e_list e_l)
+     | SOME e' => SOME e')
+   | e_acc e' x =>
+    (case e_get_next_subexp e' of
+     | NONE => SOME (e_acc e' x)
+     | SOME e'' => SOME e'')
+   | e_unop unop e' =>
+    (case e_get_next_subexp e' of
+     | NONE => SOME (e_unop unop e')
+     | SOME e'' => SOME e'')
+   | e_cast cast e' =>
+    (case e_get_next_subexp e' of
+     | NONE => SOME (e_cast cast e')
+     | SOME e'' => SOME e'')
+   | e_binop e' binop e'' =>
+    (case e_get_next_subexp e' of
+     | NONE =>
+      if is_short_circuitable binop
+      then SOME (e_binop e' binop e'')
+      else
+       (case e_get_next_subexp e'' of
+        | NONE =>
+         SOME (e_binop e' binop e'')
+        | SOME e''' => SOME e''')
+     | SOME e''' => SOME e''')
+   | e_concat e' e'' =>
+    (case e_get_next_subexp e' of
+     | NONE =>
+      (case e_get_next_subexp e'' of
+       | NONE =>
+        SOME (e_concat e' e'')
+       | SOME e''' => SOME e''')
+     | SOME e''' => SOME e''')
+   | e_slice e' e'' e''' =>
+    (case e_get_next_subexp e' of
+     | NONE =>
+      (case e_get_next_subexp e'' of
+       | NONE =>
+        (case e_get_next_subexp e''' of
+         | NONE =>
+          SOME (e_slice e' e'' e''')
+         | SOME e'''' => SOME e'''')
+       | SOME e'''' => SOME e'''')
+     | SOME e'''' => SOME e'''')
+   | e_call funn e_l =>
+    (case e_l_get_next_subexp e_l of
+     | NONE => SOME (e_call funn e_l)
+     | SOME e' => SOME e')
+   | e_select e' v_x_l x =>
+    (case e_get_next_subexp e' of
+     | NONE => SOME (e_select e' v_x_l x)
+     | SOME e'' => SOME e'')
+   | e_struct x_e_l =>
+    (case e_l_get_next_subexp $ (MAP SND) x_e_l of
+     | NONE => SOME (e_struct x_e_l)
+     | SOME e' => SOME e')
+   | e_header boolv x_e_l =>
+    (case e_l_get_next_subexp $ (MAP SND) x_e_l of
+     | NONE => SOME (e_header boolv x_e_l)
+     | SOME e' => SOME e')) /\
+ (e_l_get_next_subexp [] = NONE) /\
+ (e_l_get_next_subexp (h::t) = 
+  (case e_get_next_subexp h of
+   | NONE => e_l_get_next_subexp t
+   | SOME e' => SOME e'))
+Termination
+cheat
+End
 
-Definition astate_get_cond_def:
- astate_get_cond ((aenv, g_scope_list, arch_frame_list, status):'a astate) =
+Definition list_get_next_e_def:
+ (list_get_next_e [] = NONE) /\
+ (list_get_next_e (h::t) = 
+  (case h of
+   | e_v v => list_get_next_e t
+   | e' => SOME e'))
+End
+
+Definition stmt_get_next_e_def:
+ stmt_get_next_e stmt =
+  case stmt of
+  | stmt_empty => NONE
+  | stmt_ass lval e => SOME e
+  | stmt_cond e stmt' stmt'' =>
+   SOME e
+  | stmt_block t_scope stmt' =>
+   stmt_get_next_e stmt'
+  | stmt_ret e => SOME e
+  | stmt_seq stmt' stmt'' =>
+   stmt_get_next_e stmt'
+  | stmt_trans e => SOME e
+  | stmt_app x e_l =>
+   list_get_next_e e_l
+  | stmt_ext => NONE
+End
+
+Definition stmt_get_next_e_subexp_def:
+ stmt_get_next_e_subexp stmt =
+  case stmt_get_next_e stmt of
+  | SOME e => e_get_next_subexp e
+  | NONE => NONE
+End
+
+(*
+val branch_cond_opt = rhs $ concl $ EVAL “stmt_get_cond (stmt_cond
+               (e_binop (e_v (v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8)))
+                  binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
+               (stmt_ass
+                  (lval_field (lval_varname (varn_name "standard_meta"))
+                     "egress_spec")
+                  (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
+               (stmt_ass
+                  (lval_field (lval_varname (varn_name "standard_meta"))
+                     "egress_spec")
+                  (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9)))))”;
+
+next_e_has_free_vars “(e_binop
+                    (e_acc
+                       (e_v
+                          (v_struct
+                             [("e",v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8));
+                              ("t",
+                               v_bit
+                                 ([F; F; F; T; F; F; F; T; F; F; F; T; F; F;
+                                   F; T],16));
+                              ("l",v_bit ([F; F; F; F; F; F; F; F],8));
+                              ("r",v_bit ([F; F; F; F; F; F; F; F],8));
+                              ("v",v_bit ([T; F; T; T; F; F; F; F],8))])) "e")
+                    binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))”
+
+*)
+*)
+Definition astate_get_top_stmt_def:
+ astate_get_top_stmt ((aenv, g_scope_list, arch_frame_list, status):'a astate) =
   case arch_frame_list of
   | arch_frame_list_empty => NONE
   | arch_frame_list_regular frame_list =>
@@ -42,9 +180,31 @@ Definition astate_get_cond_def:
     | ((funn, stmt_stack, scope_list)::t) =>
      (case stmt_stack of
       | [] => NONE
-      | (h'::t') => stmt_get_cond h'
+      | (h'::t') => SOME h'
      )
    )
+End
+
+Definition astate_get_cond_def:
+ astate_get_cond astate =
+  case astate_get_top_stmt astate of
+  | SOME stmt => stmt_get_cond stmt
+  | NONE => NONE
+End
+
+(*
+Definition astate_get_next_e_subexp_def:
+ astate_get_next_e_subexp astate =
+  case astate_get_top_stmt astate of
+  | SOME stmt => stmt_get_next_e_subexp stmt
+  | NONE => NONE
+End
+
+Definition astate_get_next_e_def:
+ astate_get_next_e astate =
+  case astate_get_top_stmt astate of
+  | SOME stmt => stmt_get_next_e stmt
+  | NONE => NONE
 End
 
 Definition is_cond_red_next_def:
@@ -53,6 +213,277 @@ Definition is_cond_red_next_def:
   | SOME cond => T
   | NONE => F
 End
+*)
+
+(* TODO: The below two are also found in p4_testLib.sml - put elsewhere? *)
+(* TODO: For some reason, step_thm sometimes has an antecedent, sometimes not. Find out
+ * what's going on and unify the form. *)
+fun the_final_state_imp step_thm =
+ let
+  val step_thm_tm = concl step_thm
+ in
+  dest_some $ snd $ dest_eq $ 
+   (if is_imp step_thm_tm
+    then snd $ dest_imp $ step_thm_tm
+    else step_thm_tm)
+ end
+val simple_arith_ss = pure_ss++numSimps.REDUCE_ss
+
+fun get_actx step_thm =
+ let
+  val step_thm_tm = concl step_thm
+ in
+  #1 $ dest_arch_multi_exec $ fst $ dest_eq $ 
+   (if is_imp step_thm_tm
+    then snd $ dest_imp $ step_thm_tm
+    else step_thm_tm)
+ end
+
+(* TODO: Move to syntax library *)
+fun dest_actx actx =
+ case spine_pair actx of
+    [ab_list, pblock_map, ffblock_map, input_f, output_f, copyin_pbl, copyout_pbl, apply_table_f, ext_fun_map, func_map] => (ab_list, pblock_map, ffblock_map, input_f, output_f, copyin_pbl, copyout_pbl, apply_table_f, ext_fun_map, func_map)
+  | _ => raise (ERR "dest_actx" ("Invalid actx shape: "^(term_to_string actx)))
+;
+fun dest_astate astate =
+ case spine_pair astate of
+    [aenv, g_scope_list, arch_frame_list, status] => (aenv, g_scope_list, arch_frame_list, status)
+  | _ => raise (ERR "dest_astate" ("Invalid astate shape: "^(term_to_string astate)))
+;
+(* TODO: Fix this hack *)
+fun dest_aenv aenv =
+ let
+  val (i, aenv') = dest_pair aenv
+  val (io_list, aenv'') = dest_pair aenv'
+  val (io_list', ascope) = dest_pair aenv''
+ in
+  (i, io_list, io_list', ascope)
+ end
+;
+
+(* TODO: Definition a HOL4 function for this for now, would be a pain in the ass otherwise *)
+Definition get_b_func_map_def:
+ get_b_func_map i ab_list pblock_map =
+  case EL i ab_list of
+  | (arch_block_pbl f e_l) =>
+   (case ALOOKUP pblock_map f of
+    | SOME (pblock_regular pbl_type b_func_map t_scope pars_map tbl_map) =>
+     SOME b_func_map
+    | NONE => NONE)
+  | _ => NONE
+End
+
+fun get_b_func_map i ab_list pblock_map =
+ rhs $ concl $ EVAL “get_b_func_map ^i ^ab_list ^pblock_map”
+;
+
+(* TODO: This should be done in pre-processing, not at every step *)
+fun get_f_maps step_thm =
+ let
+  val astate = the_final_state_imp step_thm
+  val actx = get_actx step_thm
+  val (ab_list, pblock_map, _, _, _, _, _, _, ext_fun_map, func_map) = dest_actx actx
+  val (aenv, _, _, _) = dest_astate astate
+  val (i, _, _, _) = dest_aenv aenv
+  val b_func_map_opt = get_b_func_map i ab_list pblock_map
+ in
+  if is_some b_func_map_opt
+  then (func_map, dest_some b_func_map_opt, ext_fun_map)
+  else (func_map, “[]:b_func_map”, ext_fun_map)
+ end
+;
+
+(* TODO: Get rid of EVAL hack *)
+fun get_funn_dirs funn (func_map, b_func_map, ext_fun_map) =
+ let
+  val funn_sig_opt = rhs $ concl $ EVAL “lookup_funn_sig ^funn ^func_map ^b_func_map ^ext_fun_map”
+ in
+  if is_some funn_sig_opt
+  then
+    fst $ dest_list $ rhs $ concl $ EVAL “MAP SND ^(dest_some funn_sig_opt)”
+  else raise (ERR "get_funn_dirs" ("Signature of funn not found in function maps: "^(term_to_string funn)))
+ end
+;
+
+(* TODO: Get rid of EVAL hack *)
+fun is_arg_red (arg, dir) =
+ if is_d_out dir
+ then term_eq T (rhs $ concl $ EVAL “is_e_lval ^arg”) (* Must be lval *)
+ else is_e_v arg (* Must be constant *)
+;
+
+(* TODO: This needs a map between function names and the directions of their parameters *)
+fun e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e =
+ if is_e_v e
+ then NONE
+ else if is_e_var e
+ then SOME (fn e => e)
+ else if is_e_list e
+ then
+  let
+   val e_list = dest_e_list e
+  in
+   (case e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) (fst $ dest_list e_list) 0 of
+      SOME (f, i) => SOME (f o el (i+1) o fst o dest_list o dest_e_list)
+    | NONE => NONE)
+  end
+ else if is_e_acc e
+ then
+  let
+   val (e', x) = dest_e_acc e
+  in
+   if is_e_v e'
+   then SOME (fn e => e)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o fst o dest_e_acc)
+     | NONE => NONE)
+  end
+ else if is_e_unop e
+ then
+  let
+   val (unop, e') = dest_e_unop e
+  in
+   if is_e_v e'
+   then SOME (fn e => e)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o snd o dest_e_unop)
+     | NONE => NONE)
+  end
+ else if is_e_cast e
+ then
+  let
+   val (cast, e') = dest_e_cast e
+  in
+   if is_e_v e'
+   then SOME (fn e => e)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o snd o dest_e_cast)
+     | NONE => NONE)
+  end
+ else if is_e_binop e
+ then
+  let
+   val (e', binop, e'') = dest_e_binop e
+  in
+   if is_e_v e'
+   then
+    if is_e_v e''
+    then SOME (fn e => e)
+    else
+     (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e'' of
+        SOME f => SOME (f o #3 o dest_e_binop)
+      | NONE => NONE)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o #1 o dest_e_binop)
+     | NONE => NONE)
+  end
+ else if is_e_concat e
+ then
+  let
+   val (e', e'') = dest_e_concat e
+  in
+   if is_e_v e'
+   then
+    if is_e_v e''
+    then SOME (fn e => e)
+    else
+     (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e'' of
+        SOME f => SOME (f o snd o dest_e_concat)
+      | NONE => NONE)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o fst o dest_e_concat)
+     | NONE => NONE)
+  end
+ else if is_e_slice e
+ then
+  let
+   val (e', e'', e''') = dest_e_slice e
+  in
+   if is_e_v e'
+   then
+    if is_e_v e''
+    then
+     if is_e_v e'''
+     then SOME (fn e => e)
+     else
+      (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e''' of
+         SOME f => SOME (f o #3 o dest_e_slice)
+       | NONE => NONE)
+    else
+     (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e'' of
+        SOME f => SOME (f o #2 o dest_e_slice)
+      | NONE => NONE)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o #1 o dest_e_slice)
+     | NONE => NONE)
+  end
+ else if is_e_call e
+ then
+  let
+   val (funn, e_list) = dest_e_call e
+   val d_list = get_funn_dirs funn (func_map, b_func_map, ext_fun_map)
+  in
+   (case e_get_next_subexp_syntax_f_args (func_map, b_func_map, ext_fun_map) (zip (fst $ dest_list e_list) d_list) 0 of
+      SOME (f, i) => SOME (f o el (i+1) o fst o dest_list o snd o dest_e_call)
+    | NONE => NONE)
+  end
+ else if is_e_select e
+ then
+  let
+   val (e', v_x_list, x) = dest_e_select e
+  in
+   if is_e_v e'
+   then SOME (fn e => e)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e' of
+       SOME f => SOME (f o #1 o dest_e_select)
+     | NONE => NONE)
+  end
+ else if is_e_struct e
+ then
+  let
+   val x_e_list = dest_e_struct e
+  in
+   (case e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) ((map (snd o dest_pair)) $ fst $ dest_list x_e_list) 0 of
+      SOME (f, i) => SOME (f o el (i+1) o (map (snd o dest_pair)) o fst o dest_list o dest_e_struct)
+    | NONE => NONE)
+  end
+ else if is_e_header e
+ then
+  let
+   val (boolv, x_e_list) = dest_e_header e
+  in
+   (case e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) ((map (snd o dest_pair)) $ fst $ dest_list x_e_list) 0 of
+      SOME (f, i) => SOME (f o el (i+1) o (map (snd o dest_pair)) o fst o dest_list o snd o dest_e_header)
+    | NONE => NONE)
+  end
+ else raise (ERR "e_get_next_subexp_syntax_f" ("Unsupported expression: "^(term_to_string e)))
+and e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) []     _ = NONE
+  | e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) (h::t) i =
+   (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) h of
+      SOME f => SOME (f, i)
+    | NONE => e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) t (i+1))
+and e_get_next_subexp_syntax_f_args (func_map, b_func_map, ext_fun_map) []     _ = NONE
+  | e_get_next_subexp_syntax_f_args (func_map, b_func_map, ext_fun_map) ((arg, dir)::t) i =
+   if is_arg_red (arg, dir)
+   then e_get_next_subexp_syntax_f_args (func_map, b_func_map, ext_fun_map) t (i+1)
+   else
+    (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) arg of
+       SOME f => SOME (f, i)
+     | NONE => e_get_next_subexp_syntax_f_args (func_map, b_func_map, ext_fun_map) t (i+1))
+;
+
+fun get_next_subexp (func_map, b_func_map, ext_fun_map) e =
+ case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e of
+   SOME f => SOME (f e)
+ | NONE => NONE
+;
 
 (* Can use the SML function "free_vars" to check if expression to be
  * reduced contains any free variables. We should probably only perform
@@ -60,11 +491,158 @@ End
  * a free variable. But even this subexpression reduction should be OK for
  * certain expressions: for example, bit slicing and casting if all
  * free variables involved are Booleans. *)
+(* TODO: Check for exceptions *)
+fun next_subexp_has_free_vars (func_map, b_func_map, ext_fun_map) e =
+ case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) e of
+   SOME f => not $ null $ free_vars $ f e
+ | NONE => false
+;
+
+fun stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt =
+ if is_stmt_empty stmt
+ then NONE
+ else if is_stmt_ass stmt
+ then 
+  let
+   val (lval, e) = dest_stmt_ass stmt
+  in
+   if is_e_v e
+   then NONE
+   else SOME (snd o dest_stmt_ass)
+  end
+ else if is_stmt_cond stmt
+ then
+  let
+   val (e, stmt', stmt'') = dest_stmt_cond stmt
+  in
+   if is_e_v e
+   then NONE
+   else SOME (#1 o dest_stmt_cond)
+  end
+ else if is_stmt_block stmt
+ then
+  let
+   val (t_scope, stmt') = dest_stmt_block stmt
+  in
+   (case stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt' of
+      SOME f => SOME (f o snd o dest_stmt_block)
+    | NONE => NONE)
+  end
+ else if is_stmt_ret stmt
+ then 
+  let
+   val e = dest_stmt_ret stmt
+  in
+   if is_e_v e
+   then NONE
+   else SOME dest_stmt_ret
+  end
+ else if is_stmt_seq stmt
+ then
+  let
+   val (stmt', stmt'') = dest_stmt_seq stmt
+  in
+   (case stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt' of
+      SOME f => SOME (f o fst o dest_stmt_seq)
+    | NONE => NONE)
+  end
+ else if is_stmt_trans stmt
+ then 
+  let
+   val e = dest_stmt_trans stmt
+  in
+   if is_e_v e
+   then NONE
+   else SOME dest_stmt_trans
+  end
+ else if is_stmt_app stmt
+ then
+  let
+   val (x, e_list) = dest_stmt_app stmt
+  in
+   (* TODO: A little overkill. Make a stmt_get_next_e_syntax_f_list instead *)
+   (case e_get_next_subexp_syntax_f_list (func_map, b_func_map, ext_fun_map) (fst $ dest_list e_list) 0 of
+      SOME (f, i) => SOME (el (i+1) o fst o dest_list o snd o dest_stmt_app)
+    | NONE => NONE)
+  end
+ else if is_stmt_ext stmt
+ then NONE
+ else raise (ERR "stmt_get_next_e_syntax_f" ("Unsupported statement: "^(term_to_string stmt)))
+;
+
+fun get_next_e (func_map, b_func_map, ext_fun_map) stmt =
+ case stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) stmt of
+   SOME f => SOME (f stmt)
+ | NONE => NONE
+;
+
+fun astate_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) astate =
+ let
+  val (aenv, g_scope_list, arch_frame_list, status) = dest_astate astate
+ in
+  if is_arch_frame_list_empty arch_frame_list
+  then NONE
+  else
+   let
+    val frame_list = fst $ dest_list $ dest_arch_frame_list_regular arch_frame_list
+   in
+    if null frame_list
+    then NONE
+    else
+     let
+      val [funn, stmt_stack, scope_list] = strip_pair (el 1 frame_list)
+      val stmt_stack' = fst $ dest_list stmt_stack
+     in
+      if null stmt_stack'
+      then NONE
+      else
+      (case stmt_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) (el 1 stmt_stack') of
+         SOME next_e_syntax_f =>
+        SOME (next_e_syntax_f o (el 1) o fst o dest_list o (el 2) o strip_pair o (el 1) o fst o dest_list o dest_arch_frame_list_regular o #3 o dest_astate)
+       | NONE => NONE)
+     end
+   end
+ end
+;
+
+fun astate_get_next_e (func_map, b_func_map, ext_fun_map) astate =
+ let
+  val (aenv, g_scope_list, arch_frame_list, status) = dest_astate astate
+ in
+  if is_arch_frame_list_empty arch_frame_list
+  then NONE
+  else
+   let
+    val frame_list = fst $ dest_list $ dest_arch_frame_list_regular arch_frame_list
+   in
+    if null frame_list
+    then NONE
+    else
+     let
+      val [funn, stmt_stack, scope_list] = strip_pair (el 1 frame_list)
+      val stmt_stack' = fst $ dest_list stmt_stack
+     in
+      if null stmt_stack'
+      then NONE
+      else get_next_e (func_map, b_func_map, ext_fun_map) (el 1 stmt_stack')
+     end
+   end
+ end
+;
+
+(*
 fun next_e_has_free_vars e =
  if is_e_v e
  then not $ null $ free_vars e
  else if is_e_var e
  then false
+ else if is_e_list e
+ then
+  let
+   val e_list = dest_e_list e
+  in
+   next_e_has_free_vars_list (dest_list e_list)
+  end
  else if is_e_acc e
  then
   let
@@ -158,7 +736,6 @@ fun next_e_has_free_vars e =
   in
    next_e_has_free_vars_list ((map (snd o dest_pair)) $ fst $ dest_list x_e_list)
   end
- (* Unsupported: e_list *)
  else raise (ERR "next_e_has_free_vars" ("Unsupported expression: "^(term_to_string e)))
 and next_e_has_free_vars_list []     = false
   | next_e_has_free_vars_list (h::t) =
@@ -166,14 +743,20 @@ and next_e_has_free_vars_list []     = false
    then true
    else next_e_has_free_vars_list t
 ;
-
+*)
 
 (* Symbolic executor should do similar things as eval_under_assum, but on every iteration
  * check if conditional is next to be reduced, then next_e_has_free_vars.
  *
  * Handler consists of:
  * get_branch_cond: Function that tells if to perform branch. Returns NONE if no, SOME cond
- * if yes, where cond is the condition (a term) to branch upon.
+ * if yes, where cond is the condition (a term) to branch upon. Only needs the current
+ * step_thm as parameter.
+ *
+ * comp_thm: Theorem which composes step theorems
+ *
+ * take_regular_step: Function that returns a new step theorem. The core problem to solve
+ * when implementing this is deciding what to eval/rewrite.
  *
  * new free variable introduction *)
 
@@ -185,75 +768,163 @@ and next_e_has_free_vars_list []     = false
  * 
  * *)
 
-local
-(* TODO: The below two are also found in p4_testLib.sml - put elsewhere? *)
-fun the_final_state_imp step_thm = dest_some $ snd $ dest_eq $ snd $ dest_imp $ concl step_thm
-val simple_arith_ss = pure_ss++numSimps.REDUCE_ss
+(* TEST *)
+val branch_cond = “(e_binop (e_v (v_bit ([e1; e2; e3; e4; e5; e6; e7; e8],8)))
+                    binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))”;
 
+(* RESTR_EVAL_RULE constants: *)
+val p4_stop_eval_consts =
+ [(* “word_1comp”, (* Should be OK? ¬v2w [x; F; T] = v2w [¬x; T; F] *) *)
+  “word_2comp”,
+  “word_mul”,
+  “word_div”,
+  “word_mod”,
+  “word_add”,
+  “saturate_add”,
+  “word_sub”,
+  “saturate_sub”,
+  “word_lsl_bv”, (* TODO: OK to evaluate if second operand has no free variables *)
+  “word_lsr_bv”, (* TODO: OK to evaluate if second operand has no free variables *)
+  (* “word_and”, (* Should be OK? w2v (v2w [x; F; T] && v2w [y; F; T]) = [x ∧ y; F; T] *) *)
+  (* “word_xor”, (* Should be OK? w2v (v2w [x; F; T] ⊕ v2w [y; F; T]) = [x ⇎ y; F; F] *) *)
+  (* “word_or”, (* Should be OK? w2v (v2w [x; F; T] ‖ v2w [y; F; T]) = [x ∨ y; F; T] *) *)
+  “word_ls”,
+  “word_hs”,
+  “word_lo”,
+  “word_hi”
+];
+
+(* Function that decides whether to branch or not *)
+(* TODO: This is a P4-specific function that has been factored out, make it an argument of
+ * the generic symb_exec *)
+(* TODO: Add more constants to RESTR_EVAL_CONV? *)
+fun p4_should_branch step_thm =
+ let
+  val astate = the_final_state_imp step_thm
+  val branch_cond_opt = rhs $ concl $ RESTR_EVAL_CONV p4_stop_eval_consts “astate_get_cond ^astate”
+ in
+  if is_some branch_cond_opt
+  then
+   let
+    val branch_cond = dest_some branch_cond_opt
+   in
+    if is_e_v branch_cond andalso not $ null $ free_vars branch_cond
+    then SOME (dest_v_bool $ dest_e_v branch_cond)
+    else NONE
+   end
+  else NONE
+ end
+;
+
+
+
+fun p4_regular_step ctx stop_consts_rewr stop_consts_never comp_thm (path_cond, step_thm) =
+ let
+  val astate = the_final_state_imp step_thm
+  val step_thm2 =
+   eval_ctxt_gen (stop_consts_rewr@stop_consts_never@p4_stop_eval_consts)
+                 (stop_consts_never@p4_stop_eval_consts) path_cond
+                 (mk_arch_multi_exec (ctx, astate, 1));
+  (* TODO: This could take only astate and actx as args *)
+  val (func_map, b_func_map, ext_fun_map) = get_f_maps step_thm
+  (* TODO: Do this in a nicer way... *)
+  val next_e_opt = astate_get_next_e (func_map, b_func_map, ext_fun_map) astate
+  val extra_rewr_thms =
+   (case astate_get_next_e_syntax_f (func_map, b_func_map, ext_fun_map) astate of
+      NONE => [] (* Reduction did not even consider reducing an e *)
+    | SOME next_e_syntax_f =>
+     (case e_get_next_subexp_syntax_f (func_map, b_func_map, ext_fun_map) (next_e_syntax_f astate) of
+        SOME next_subexp_syntax_f =>
+       let
+        val next_subexp = next_subexp_syntax_f (next_e_syntax_f astate)
+       in
+        if null $ free_vars $ next_subexp
+        then (* Reduction from a subexp without free variables *)
+         let
+          (* Then, get the resulting subexp *)
+          val subexp_red_res =
+           next_subexp_syntax_f $ next_e_syntax_f $ the_final_state_imp step_thm2
+          (* Evaluate the subexp without restrictions *)
+          val subexp_red_res_EVAL = EVAL subexp_red_res
+         in
+          (* Now, rewrite with this result *)
+          [subexp_red_res_EVAL]
+         end
+        else [] (* Reduction from a subexp with free variables *)
+       end
+      | NONE =>
+       (* e_call was reduced *)
+       []))
+ in
+  SIMP_RULE simple_arith_ss extra_rewr_thms
+   (MATCH_MP (MATCH_MP comp_thm step_thm) step_thm2)
+ end
+;
+
+local
 (* Symbolic execution with branching on if-then-else
  * Width-first scheduling (positive case first)
  * Note that branching consumes one step of fuel
- * Note that the static ctxt is shared between the branches, whereas the dynamic path
- * conditions are different and not shared *)
-fun symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm [] finished_list =
+ * Here, the static ctxt and the dynamic path condition have been merged.
+ * Currently, the path condition is stripped down as much as possible from p4-specific stuff
+ * (another design priority could be legibility and keeping the connection to the P4 constructs). *)
+fun symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm [] finished_list =
  finished_list
-  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm
+  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm
                ((path_cond, step_thm, 0)::t) finished_list =
-   symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm t
+   symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm t
               (finished_list@[(path_cond, step_thm)])
-  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm
+  | symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm
                ((path_cond, step_thm, fuel)::t) finished_list =
- let
-  val curr_state = the_final_state_imp step_thm
-  (* Check if we should branch or take regular step *)
-  (* TODO: Use separate handler for this - factor out the below into a separate function *)
-  val branch_cond_opt = rhs $ concl $ EVAL “astate_get_cond curr_state”
- in
-  if is_some branch_cond_opt
-  (* Branch + prune *)
-  then
-   let
-    (* Get branch condition term *)
-    val branch_cond = dest_some branch_cond_opt
-    (* Get new rewriting contexts for the positive and negative cases *)
-    val path_cond_cond = CONJ path_cond (ASSUME branch_cond)
-    val path_cond_neg_cond = CONJ path_cond (ASSUME $ mk_neg branch_cond)
-    (* Check if the new rewriting contexts contradict themselves *)
-    val is_path_cond_cond_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_cond)
-    val is_path_cond_neg_cond_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_neg_cond)
-    (* Prune away symbolic states with contradictory path_cond, otherwise add them to
-     * end of procesing queue. Positive case goes before negative. *)
-    val next_astate_cond =
-     if is_path_cond_cond_F then [] else [(path_cond_cond, step_thm, fuel-1)]
-    val next_astate_neg_cond =
-     if is_path_cond_neg_cond_F then [] else [(path_cond_neg_cond, step_thm, fuel-1)]
-   in
-    symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm (t@(next_astate_cond@next_astate_neg_cond)) finished_list
-   end
-  (* Do not branch - compute one step *)
-  else
-   let
-    val step_thm2 =
-     eval_ctxt_gen (stop_consts_rewr@stop_consts_never) stop_consts_never ctxt (mk_arch_multi_exec (ctx, curr_state, 1));
-    val comp_step_thm =
-     SIMP_RULE simple_arith_ss []
-      (MATCH_MP (MATCH_MP comp_thm step_thm) step_thm2);
-   in
-    symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm (t@[(path_cond, comp_step_thm, fuel-1)]) finished_list
-   end
- end
-
+   (* Check if we should branch or take regular step
+    * p4_should_branch can be made an argument: it takes the current step theorem
+    * and returns a term with the branch condition, with which you can split the
+    * path condition *)
+   (case p4_should_branch step_thm of
+     SOME branch_cond =>
+     (* Branch + prune *)
+     let
+      (* Get new path conditions for the positive and negative cases *)
+      val path_cond_pos = CONJ path_cond (ASSUME (mk_eq (branch_cond, T)))
+      val path_cond_neg = CONJ path_cond (ASSUME (mk_eq (branch_cond, F)))
+      (* Check if the new path conditions contradict themselves *)
+      val is_path_cond_pos_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_pos)
+      val is_path_cond_neg_F = Feq $ concl (SIMP_RULE std_ss [] path_cond_neg)
+      (* Prune away symbolic states with contradictory path_cond, otherwise add them to
+       * end of procesing queue. Positive case goes before negative. *)
+      val next_astate_pos =
+       if is_path_cond_pos_F
+       then []
+       else [(path_cond_pos, DISCH_CONJUNCTS_ALL $ REWRITE_RULE [path_cond_pos] step_thm, fuel-1)]
+      val next_astate_neg =
+       if is_path_cond_neg_F
+       then []
+       else [(path_cond_neg, DISCH_CONJUNCTS_ALL $ REWRITE_RULE [path_cond_neg] step_thm, fuel-1)]
+     in
+      symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm
+                 (t@(next_astate_pos@next_astate_neg)) finished_list
+     end
+    | NONE =>
+     (* Do not branch - compute one regular step *)
+     let
+      val next_step_thm =
+       p4_regular_step ctx stop_consts_rewr stop_consts_never comp_thm (path_cond, step_thm)
+     in
+      symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm
+                 (t@[(path_cond, next_step_thm, fuel-1)]) finished_list
+     end)
 in
-fun symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never ctxt path_cond fuel =
+fun symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond fuel =
  let
-  (* TODO: Also branch check here *)
+  (* TODO: Also branch check here? *)
   val step_thm =
-   eval_ctxt_gen (stop_consts_rewr@stop_consts_never) stop_consts_never ctxt (mk_arch_multi_exec (ctx, init_astate, 1));
+   eval_ctxt_gen (stop_consts_rewr@stop_consts_never) stop_consts_never path_cond (mk_arch_multi_exec (ctx, init_astate, 1));
+  (* TODO: Make arch_multi_exec_comp_n_tl_assl "init_comp_thm" and an argument *)
   val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl;
  in
   if fuel = 1
   then [(path_cond, step_thm)]
-  else symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never ctxt comp_thm [(path_cond, step_thm, (fuel-1))] []
+  else symb_exec' arch_ty ctx stop_consts_rewr stop_consts_never comp_thm [(path_cond, step_thm, (fuel-1))] []
  end
 end;
 
@@ -375,11 +1046,38 @@ val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; 
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
 
 (* symb_exec: *)
-symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 23
+(* Parameter assignment for debugging: *)
+val arch_ty = p4_v1modelLib.v1model_arch_ty
+val ctx = symb_exec1_actx
+val init_astate = symb_exec1_astate_symb
+val stop_consts_rewr = []
+val stop_consts_never = []
+val path_cond = (ASSUME T)
+val fuel = 2
 
-(* TODO: Something goes wrong here: *)
-symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 24
+val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
 
-symb_exec p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate_symb [] [] (ASSUME T) (ASSUME T) 25
+val [(path_cond, step_thm)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 24
+
+(* Something goes wrong here *)
+val [(path_cond, step_thm), (path_cond2, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25
+
+val [(path_cond, step_thm), (path_cond2, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 26
+
+
+
+
+symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 13
+
+
+
+
+
+
+
+
 
 val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -161,7 +161,7 @@ val (res_tree, res_elems) =
 
    Join happens here:
 val (res_tree, res_elems) =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 44;
 
 val [res_elem1, res_elem2] = res_elems
 

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -6,6 +6,11 @@ open p4_symb_execLib;
 
 val _ = new_theory "p4_symb_exec_test1";
 
+(* Test 1:
+ * There's a single if-statement that branches on symbolic bits.
+ * Postcondition holds regardless of which path was taken.
+ *
+ * This tests if basic branching and unification works. *)
 
 val symb_exec1_actx = ``([arch_block_inp;
   arch_block_pbl "p"
@@ -107,6 +112,8 @@ val symb_exec1_actx = ``([arch_block_inp;
     ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
  [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
 
+(*
+(* Concrete state from old example program *)
 val symb_exec1_astate = rhs $ concl $ EVAL “(p4_append_input_list [([F; F; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
  ([F; F; F; F; F; F; T; F; F; F; F; T; F; F; F; T; T; F; F; F; F; F; F; T; F;
@@ -115,16 +122,22 @@ val symb_exec1_astate = rhs $ concl $ EVAL “(p4_append_input_list [([F; F; F; 
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
  ([T; T; T; T; F; T; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
-
+*)
 
 (*
 (* eval_under_assum: *)
 GEN_ALL $ eval_under_assum p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate [] [] (ASSUME T) 10;
 *)
 
+(* As symbolic packet, generate something like this:
+  
+   data = [b1; b2; b3; b4; b5; b6; b7; b8]
+   port = p
+
+*)
+
 val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
-
 
 
 (* symb_exec: *)
@@ -136,25 +149,98 @@ val stop_consts_rewr = []
 val stop_consts_never = []
 val path_cond = (ASSUME T)
 val fuel = 2
-(*
+(* For debugging:
 val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
 *)
 
-(* Before branch
-val [(path_cond, step_thm)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 24
+(* For debugging, branch happens here:
+val [(path_cond_res, step_thm), (path_cond2_res, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
 *)
 
-(* Branch happens here *)
-val [(path_cond, step_thm), (path_cond2, step_thm2)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25
+(* Finishes at 45 steps (one step of which is a symbolic branch)
+ * (higher numbers as arguments will work, but do no extra computations) *)
 
+val [(path_cond_res, step_thm), (path_cond2_res, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 50;
+
+open p4_auxTheory;
+
+(*******************************)
+(* Step 1: prove postcondition *)
+
+(* True if the output packet queue contains a single packet with
+ * the provided output port *)
+Definition packet_has_port_def:
+ packet_has_port (((i, in_out_list, in_out_list', scope), g_scope_list, arch_frame_list, status):'a astate) port_ok =
+  case in_out_list' of
+    [] => F
+  | [(data, port)] => port = port_ok
+  | _ => F
+End
+
+val postcond = “(\s. packet_has_port s 1 \/ packet_has_port s 2):v1model_ascope astate -> bool”;
+
+Theorem symb_exec_add_postcond:
+!P f s s' Q.
+(P ==> f s = SOME s') ==>
+Q s' ==>
+(P ==> f s = SOME s' /\ Q s')
+Proof
+metis_tac []
+QED
+
+val step_thm' = HO_MATCH_MP symb_exec_add_postcond step_thm;
+val postcond_thm = EQT_ELIM $ SIMP_CONV (srw_ss()) [packet_has_port_def] $ mk_comb (postcond, the_final_state_imp step_thm);
+val step_postcond_thm = MATCH_MP step_thm' postcond_thm;
+
+val step_thm2' = HO_MATCH_MP symb_exec_add_postcond step_thm2;
+val postcond_thm2 = EQT_ELIM $ SIMP_CONV (srw_ss()) [packet_has_port_def] $ mk_comb (postcond, the_final_state_imp step_thm2);
+val step_postcond_thm2 = MATCH_MP step_thm2' postcond_thm2;
+
+(**************************************)
+(* Step 2: rewrite into contract form *)
+
+(* TODO: Eliminate n, put initial state in precondition somehow? *)
+Definition p4_contract_def:
+ p4_contract P ctx s n Q =
+  (P ==> arch_multi_exec ctx s n <> NONE /\ !s'. arch_multi_exec ctx s n = SOME s' ==> Q s')
+End
+
+Theorem p4_exec_univ:
+!P ctx s n s' Q.
+(P ==> arch_multi_exec ctx s n = SOME s' /\ Q s') ==>
+p4_contract P ctx s n Q
 (*
-val [(path_cond, step_thm), (path_cond2, step_thm2)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 26
-
-val [(path_cond, step_thm), (path_cond2, step_thm2)] =
- symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 28
+(P ==> arch_multi_exec ctx s n <> NONE /\ !s'. arch_multi_exec ctx s n = SOME s' ==> Q s')
 *)
+Proof
+fs[p4_contract_def]
+QED
+
+val step_postcond_ct_thm = MATCH_MP p4_exec_univ step_postcond_thm
+val step_postcond_ct_thm2 = MATCH_MP p4_exec_univ step_postcond_thm2
+
+(***********************)
+(* Step 3: unification *)
+
+Theorem p4_symb_exec_unify:
+(*
+!P1 P2 f s Q.
+(P1 /\ P2 ==> f s <> NONE /\ !s'. f s = SOME s' ==> Q s') ==>
+(~P1 /\ P2 ==> f s <> NONE /\ !s'. f s = SOME s' ==> Q s') ==>
+P2 ==> f s <> NONE /\ !s'. f s = SOME s' ==> Q s'
+*)
+!P1 P2 ctx s n Q.
+p4_contract (P1 /\ P2) ctx s n Q ==>
+p4_contract (~P1 /\ P2) ctx s n Q ==>
+p4_contract P2 ctx s n Q
+Proof
+fs[p4_contract_def] >>
+metis_tac []
+QED
+
+val thm1 = MATCH_MP p4_symb_exec_unify step_postcond_ct_thm
+val thm2 = MATCH_MP thm1 step_postcond_ct_thm2
 
 val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -139,6 +139,7 @@ GEN_ALL $ eval_under_assum p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_ex
 val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
 
+open p4_auxTheory;
 
 (* symb_exec: *)
 (* Parameter assignment for debugging: *)
@@ -150,17 +151,22 @@ val stop_consts_never = []
 val path_cond = (ASSUME T)
 val fuel = 2
 val n_max = 50;
+val precond = “T”;
 val postcond = “(\s. packet_has_port s 1 \/ packet_has_port s 2):v1model_ascope astate -> bool”;
 (* For debugging:
-val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
+val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] p4_exec_semTheory.arch_multi_exec_comp_n_tl_assl
 *)
 
 (* For debugging, branch happens here:
-val [(path_cond_res, step_thm), (path_cond2_res, step_thm2)] =
+val (res_tree, res_elems) =
  symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
+
+val [res_elem1, res_elem2] = res_elems
+
+val (res_id1, res_cond1, res_thm1) = res_elem1
 *)
 
-open p4_auxTheory;
+
 
 (* Finishes at 45 steps (one step of which is a symbolic branch)
  * (higher numbers as arguments will work, but do no extra computations) *)

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -159,6 +159,10 @@ val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] p4_exec_semTheory.arch_multi_e
 val (res_tree, res_elems) =
  symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
 
+   Join happens here:
+val (res_tree, res_elems) =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
+
 val [res_elem1, res_elem2] = res_elems
 
 val (res_id1, res_cond1, res_thm1) = res_elem1

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -1,0 +1,160 @@
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open p4Theory;
+
+open p4_symb_execLib;
+
+val _ = new_theory "p4_symb_exec_test1";
+
+
+val symb_exec1_actx = ``([arch_block_inp;
+  arch_block_pbl "p"
+    [e_var (varn_name "b"); e_var (varn_name "parsedHdr");
+     e_var (varn_name "meta"); e_var (varn_name "standard_metadata")];
+  arch_block_ffbl "postparser";
+  arch_block_pbl "vrfy" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "ingress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "egress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "update" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "deparser" [e_var (varn_name "b"); e_var (varn_name "hdr")];
+  arch_block_out],
+ [("p",
+   pblock_regular pbl_type_parser
+     [("p",stmt_seq stmt_empty (stmt_trans (e_v (v_str "start"))),
+       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])] []
+     [("start",
+       stmt_seq
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_in" "extract")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
+         (stmt_trans (e_v (v_str "accept"))))] []);
+  ("vrfy",
+   pblock_regular pbl_type_control
+     [("vrfy",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("update",
+   pblock_regular pbl_type_control
+     [("update",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("egress",
+   pblock_regular pbl_type_control
+     [("egress",stmt_seq stmt_empty stmt_empty,
+       [("h",d_inout); ("m",d_inout); ("sm",d_inout)])] [] [] []);
+  ("deparser",
+   pblock_regular pbl_type_control
+     [("deparser",
+       stmt_seq stmt_empty
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_out" "emit")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"])),
+       [("b",d_none); ("h",d_in)])] [] [] []);
+  ("ingress",
+   pblock_regular pbl_type_control
+     [("ingress",
+       stmt_seq stmt_empty
+         (stmt_cond
+            (e_binop
+               (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row") "e")
+               binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9))))),
+       [("h",d_inout); ("m",d_inout); ("standard_meta",d_inout)])] [] [] [])],
+ [("postparser",ffblock_ff v1model_postparser)],
+ v1model_input_f
+   (v_struct
+      [("h",
+        v_header ARB
+          [("row",
+            v_struct
+              [("e",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("t",
+                v_bit
+                  ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB;
+                    ARB; ARB; ARB; ARB; ARB],16));
+               ("l",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("r",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("v",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8))])])],
+    v_struct []),v1model_output_f,v1model_copyin_pbl,v1model_copyout_pbl,
+ v1model_apply_table_f,
+ [("header",NONE,
+   [("isValid",[("this",d_in)],header_is_valid);
+    ("setValid",[("this",d_inout)],header_set_valid);
+    ("setInvalid",[("this",d_inout)],header_set_invalid)]);
+  ("",NONE,
+   [("mark_to_drop",[("standard_metadata",d_inout)],v1model_mark_to_drop);
+    ("verify",[("condition",d_in); ("err",d_in)],v1model_verify)]);
+  ("packet_in",NONE,
+   [("extract",[("this",d_in); ("headerLvalue",d_out)],
+     v1model_packet_in_extract);
+    ("lookahead",[("this",d_in); ("targ1",d_in)],v1model_packet_in_lookahead);
+    ("advance",[("this",d_in); ("bits",d_in)],v1model_packet_in_advance)]);
+  ("packet_out",NONE,
+   [("emit",[("this",d_in); ("data",d_in)],v1model_packet_out_emit)]);
+  ("register",
+   SOME
+     ([("this",d_out); ("size",d_none); ("targ1",d_in)],register_construct),
+   [("read",[("this",d_in); ("result",d_out); ("index",d_in)],register_read);
+    ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
+ [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
+
+val symb_exec1_astate = rhs $ concl $ EVAL “(p4_append_input_list [([F; F; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([F; F; F; F; F; F; T; F; F; F; F; T; F; F; F; T; T; F; F; F; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([T; T; T; T; F; F; T; T; F; F; F; T; F; F; F; F; F; F; F; F; F; F; F; F; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0);
+ ([T; T; T; T; F; T; F; F; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
+
+
+(*
+(* eval_under_assum: *)
+GEN_ALL $ eval_under_assum p4_v1modelLib.v1model_arch_ty symb_exec1_actx symb_exec1_astate [] [] (ASSUME T) 10;
+*)
+
+val symb_exec1_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
+
+
+
+(* symb_exec: *)
+(* Parameter assignment for debugging: *)
+val arch_ty = p4_v1modelLib.v1model_arch_ty
+val ctx = symb_exec1_actx
+val init_astate = symb_exec1_astate_symb
+val stop_consts_rewr = []
+val stop_consts_never = []
+val path_cond = (ASSUME T)
+val fuel = 2
+(*
+val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
+*)
+
+(* Before branch
+val [(path_cond, step_thm)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 24
+*)
+
+(* Branch happens here *)
+val [(path_cond, step_thm), (path_cond2, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25
+
+(*
+val [(path_cond, step_thm), (path_cond2, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 26
+
+val [(path_cond, step_thm), (path_cond2, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 28
+*)
+
+val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_exec_test1Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test1Script.sml
@@ -149,9 +149,7 @@ val init_astate = symb_exec1_astate_symb
 val stop_consts_rewr = []
 val stop_consts_never = []
 val path_cond = (ASSUME T)
-val fuel = 2
 val n_max = 50;
-val precond = “T”;
 val postcond = “(\s. packet_has_port s 1 \/ packet_has_port s 2):v1model_ascope astate -> bool”;
 (* For debugging:
 val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] p4_exec_semTheory.arch_multi_exec_comp_n_tl_assl

--- a/hol/symb_exec/p4_symb_exec_test2Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test2Script.sml
@@ -1,0 +1,144 @@
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open p4Theory;
+
+open p4_symb_execLib;
+
+val _ = new_theory "p4_symb_exec_test2";
+
+(* Test 2:
+ * There's a single if-statement that branches on symbolic bits.
+ * Postcondition holds only for the then-branch.
+ * The precondition states that the then-branch should be taken.
+ *
+ * This tests if basic pruning works. *)
+
+val symb_exec2_actx = ``([arch_block_inp;
+  arch_block_pbl "p"
+    [e_var (varn_name "b"); e_var (varn_name "parsedHdr");
+     e_var (varn_name "meta"); e_var (varn_name "standard_metadata")];
+  arch_block_ffbl "postparser";
+  arch_block_pbl "vrfy" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "ingress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "egress"
+    [e_var (varn_name "hdr"); e_var (varn_name "meta");
+     e_var (varn_name "standard_metadata")];
+  arch_block_pbl "update" [e_var (varn_name "hdr"); e_var (varn_name "meta")];
+  arch_block_pbl "deparser" [e_var (varn_name "b"); e_var (varn_name "hdr")];
+  arch_block_out],
+ [("p",
+   pblock_regular pbl_type_parser
+     [("p",stmt_seq stmt_empty (stmt_trans (e_v (v_str "start"))),
+       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])] []
+     [("start",
+       stmt_seq
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_in" "extract")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
+         (stmt_trans (e_v (v_str "accept"))))] []);
+  ("vrfy",
+   pblock_regular pbl_type_control
+     [("vrfy",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("update",
+   pblock_regular pbl_type_control
+     [("update",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
+     [] [] []);
+  ("egress",
+   pblock_regular pbl_type_control
+     [("egress",stmt_seq stmt_empty stmt_empty,
+       [("h",d_inout); ("m",d_inout); ("sm",d_inout)])] [] [] []);
+  ("deparser",
+   pblock_regular pbl_type_control
+     [("deparser",
+       stmt_seq stmt_empty
+         (stmt_ass lval_null
+            (e_call (funn_ext "packet_out" "emit")
+               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"])),
+       [("b",d_none); ("h",d_in)])] [] [] []);
+  ("ingress",
+   pblock_regular pbl_type_control
+     [("ingress",
+       stmt_seq stmt_empty
+         (stmt_cond
+            (e_binop
+               (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row") "e")
+               binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
+            (stmt_ass
+               (lval_field (lval_varname (varn_name "standard_meta"))
+                  "egress_spec")
+               (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9))))),
+       [("h",d_inout); ("m",d_inout); ("standard_meta",d_inout)])] [] [] [])],
+ [("postparser",ffblock_ff v1model_postparser)],
+ v1model_input_f
+   (v_struct
+      [("h",
+        v_header ARB
+          [("row",
+            v_struct
+              [("e",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("t",
+                v_bit
+                  ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB;
+                    ARB; ARB; ARB; ARB; ARB],16));
+               ("l",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("r",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8));
+               ("v",v_bit ([ARB; ARB; ARB; ARB; ARB; ARB; ARB; ARB],8))])])],
+    v_struct []),v1model_output_f,v1model_copyin_pbl,v1model_copyout_pbl,
+ v1model_apply_table_f,
+ [("header",NONE,
+   [("isValid",[("this",d_in)],header_is_valid);
+    ("setValid",[("this",d_inout)],header_set_valid);
+    ("setInvalid",[("this",d_inout)],header_set_invalid)]);
+  ("",NONE,
+   [("mark_to_drop",[("standard_metadata",d_inout)],v1model_mark_to_drop);
+    ("verify",[("condition",d_in); ("err",d_in)],v1model_verify)]);
+  ("packet_in",NONE,
+   [("extract",[("this",d_in); ("headerLvalue",d_out)],
+     v1model_packet_in_extract);
+    ("lookahead",[("this",d_in); ("targ1",d_in)],v1model_packet_in_lookahead);
+    ("advance",[("this",d_in); ("bits",d_in)],v1model_packet_in_advance)]);
+  ("packet_out",NONE,
+   [("emit",[("this",d_in); ("data",d_in)],v1model_packet_out_emit)]);
+  ("register",
+   SOME
+     ([("this",d_out); ("size",d_none); ("targ1",d_in)],register_construct),
+   [("read",[("this",d_in); ("result",d_out); ("index",d_in)],register_read);
+    ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
+ [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
+
+val symb_exec2_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+   F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
+
+
+(* symb_exec: *)
+(* Parameter assignment for debugging: *)
+val arch_ty = p4_v1modelLib.v1model_arch_ty
+val ctx = symb_exec2_actx
+val init_astate = symb_exec2_astate_symb
+val stop_consts_rewr = []
+val stop_consts_never = []
+val path_cond = ASSUME “v2w [e1; e2; e3; e4; e5; e6; e7; e8] <+ (v2w [T; F; F; F; F; F; F; F]):word8”
+val fuel = 2
+val n_max = 50;
+val postcond = “(\s. packet_has_port s 1):v1model_ascope astate -> bool”;
+(* For debugging:
+val comp_thm = INST_TYPE [Type.alpha |-> arch_ty] arch_multi_exec_comp_n_tl_assl
+*)
+
+(* For debugging, branch happens here:
+val [(path_cond_res, step_thm), (path_cond2_res, step_thm2)] =
+ symb_exec arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond 25;
+*)
+
+(* Finishes at 45 steps (one step of which is a symbolic branch)
+ * (higher numbers as arguments will work, but do no extra computations) *)
+val contract_thm = p4_symb_exec_prove_contract arch_ty ctx init_astate stop_consts_rewr stop_consts_never path_cond n_max postcond;
+
+val _ = export_theory ();

--- a/hol/symb_exec/p4_symb_exec_test3Script.sml
+++ b/hol/symb_exec/p4_symb_exec_test3Script.sml
@@ -4,16 +4,16 @@ open p4Theory;
 
 open p4_symb_execLib;
 
-val _ = new_theory "p4_symb_exec_test2";
+val _ = new_theory "p4_symb_exec_test3";
 
-(* Test 2:
- * There's a single if-statement that branches on symbolic bits.
- * Postcondition holds only for the then-branch.
- * The precondition states that the then-branch should be taken.
+(* Test 3:
+ * There's a single select statement that branches on the LSB.
+ * Postcondition holds only for "accept".
+ * The precondition states that the accept case should be selected.
  *
- * This tests if basic pruning works. *)
+ * This tests if branching on select statement and following pruning works. *)
 
-val symb_exec2_actx = ``([arch_block_inp;
+val symb_exec3_actx = ``([arch_block_inp;
   arch_block_pbl "p"
     [e_var (varn_name "b"); e_var (varn_name "parsedHdr");
      e_var (varn_name "meta"); e_var (varn_name "standard_metadata")];
@@ -31,13 +31,22 @@ val symb_exec2_actx = ``([arch_block_inp;
  [("p",
    pblock_regular pbl_type_parser
      [("p",stmt_seq stmt_empty (stmt_trans (e_v (v_str "start"))),
-       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])] []
+       [("b",d_none); ("h",d_out); ("m",d_inout); ("sm",d_inout)])]
+     [(varn_name "sel_e",tau_bit 1,NONE)]
      [("start",
        stmt_seq
-         (stmt_ass lval_null
-            (e_call (funn_ext "packet_in" "extract")
-               [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
-         (stmt_trans (e_v (v_str "accept"))))] []);
+         (stmt_seq
+            (stmt_ass lval_null
+               (e_call (funn_ext "packet_in" "extract")
+                  [e_var (varn_name "b"); e_acc (e_var (varn_name "h")) "h"]))
+            (stmt_ass (lval_varname (varn_name "sel_e"))
+               (e_cast (cast_unsigned 1)
+                  (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row")
+                     "e"))))
+         (stmt_trans
+            (e_select (e_var (varn_name "sel_e"))
+               [(v_bit ([T],1),"accept"); (v_bit ([F],1),"reject")] "reject")))]
+     []);
   ("vrfy",
    pblock_regular pbl_type_control
      [("vrfy",stmt_seq stmt_empty stmt_empty,[("h",d_inout); ("m",d_inout)])]
@@ -62,18 +71,9 @@ val symb_exec2_actx = ``([arch_block_inp;
    pblock_regular pbl_type_control
      [("ingress",
        stmt_seq stmt_empty
-         (stmt_cond
-            (e_binop
-               (e_acc (e_acc (e_acc (e_var (varn_name "h")) "h") "row") "e")
-               binop_lt (e_v (v_bit ([T; F; F; F; F; F; F; F],8))))
-            (stmt_ass
-               (lval_field (lval_varname (varn_name "standard_meta"))
-                  "egress_spec")
-               (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9))))
-            (stmt_ass
-               (lval_field (lval_varname (varn_name "standard_meta"))
-                  "egress_spec")
-               (e_v (v_bit ([F; F; F; F; F; F; F; T; F],9))))),
+         (stmt_ass
+            (lval_field (lval_varname (varn_name "standard_meta"))
+               "egress_spec") (e_v (v_bit ([F; F; F; F; F; F; F; F; T],9)))),
        [("h",d_inout); ("m",d_inout); ("standard_meta",d_inout)])] [] [] [])],
  [("postparser",ffblock_ff v1model_postparser)],
  v1model_input_f
@@ -113,19 +113,18 @@ val symb_exec2_actx = ``([arch_block_inp;
     ("write",[("this",d_in); ("index",d_in); ("value",d_in)],register_write)])],
  [("NoAction",stmt_seq stmt_empty (stmt_ret (e_v v_bot)),[])]):v1model_ascope actx``;
 
-val symb_exec2_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
+val symb_exec3_astate_symb = rhs $ concl $ EVAL “(p4_append_input_list [([e1; e2; e3; e4; e5; e6; e7; e8; F; F; F; T; F; F; F; T; F; F; F; T; F; F; F; T; F;
    F; F; F; F; F; F; F; F; F; F; F; F; F; F; F; T; F; T; T; F; F; F; F],0)] (((0,[],[],ARB,ARB,ARB,[]),[[]],arch_frame_list_empty,status_running):v1model_ascope astate))”;
 
 
 (* symb_exec: *)
 (* Parameter assignment for debugging: *)
 val arch_ty = p4_v1modelLib.v1model_arch_ty
-val ctx = symb_exec2_actx
-val init_astate = symb_exec2_astate_symb
+val ctx = symb_exec3_actx
+val init_astate = symb_exec3_astate_symb
 val stop_consts_rewr = []
 val stop_consts_never = []
-val path_cond = ASSUME “v2w [e1; e2; e3; e4; e5; e6; e7; e8] <+ (v2w [T; F; F; F; F; F; F; F]):word8”
-val fuel = 2
+val path_cond = ASSUME “e8 = T”
 val n_max = 50;
 val postcond = “(\s. packet_has_port s 1):v1model_ascope astate -> bool”;
 (* For debugging:

--- a/hol/symb_exec/symb_execLib.sig
+++ b/hol/symb_exec/symb_execLib.sig
@@ -1,0 +1,11 @@
+signature symb_execLib =
+sig
+  include Abbrev
+
+datatype path_tree = empty | node of int * thm * (path_tree list);
+
+val symb_exec:
+ (thm * thm -> thm) * thm * (thm -> (term list * thm) option) *
+  (thm -> bool) -> thm -> int -> path_tree * (int * thm * thm) list
+
+end

--- a/hol/symb_exec/symb_execLib.sml
+++ b/hol/symb_exec/symb_execLib.sml
@@ -1,0 +1,109 @@
+structure symb_execLib :> symb_execLib = struct
+
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+open hurdUtils;
+
+datatype path_tree = empty | node of int * thm * (path_tree list);
+
+val ERR = mk_HOL_ERR "symb_exec"
+
+(* TODO: Optimize? *)
+fun insert_nodes' empty (at_id, thm, new_nodes) _ = NONE
+  | insert_nodes' (node (id, thm, nodes)) (at_id, new_thm, new_nodes) nodes_temp = 
+   if at_id = id
+   then
+    if null nodes
+    then SOME (node (id, new_thm, new_nodes))
+    else NONE (* Erroneously trying to insert new nodes in occupied position *)
+   else
+    if null nodes
+    then NONE (* Reached end of search *)
+    else
+     case insert_nodes' (hd nodes) (at_id, new_thm, new_nodes) [] of
+       SOME new_node =>
+      SOME (node (id, new_thm, nodes_temp@(new_node::(tl nodes))))
+     | NONE =>
+      insert_nodes' (node (id, thm, tl nodes)) (at_id, new_thm, new_nodes) (nodes_temp@[hd nodes]);
+
+fun insert_nodes path_tree (at_id, new_thm, new_nodes) =
+ case insert_nodes' path_tree (at_id, new_thm, new_nodes) [] of
+   SOME new_path_tree =>
+  new_path_tree
+ | NONE =>
+  raise (ERR "insert_nodes" "Inserting new path node at unknown or occupied position ");
+
+(* TODO: Rename "branch condition" to something else? Is this terminology OK? *)
+local
+(* Symbolic execution with branching on if-then-else
+ * Width-first scheduling (positive case first) of execution
+ * Note that branching consumes one step of (SML function) fuel
+ * Here, the static ctxt and the dynamic path condition have been merged.
+ * Currently, the path condition is stripped down as much as possible from p4-specific stuff
+ * (another design priority could be legibility and keeping the connection to the P4 constructs). *)
+fun symb_exec' lang_funs npaths path_tree [] finished_list = (path_tree, finished_list)
+  | symb_exec' lang_funs npaths path_tree ((path_id, path_cond, step_thm, 0)::t) finished_list =
+   symb_exec' lang_funs npaths path_tree t (finished_list@[(path_id, path_cond, step_thm)])
+  | symb_exec' (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) npaths
+               path_tree ((path_id, path_cond, step_thm, fuel)::t) finished_list =
+   (* Check if we should branch or take regular step
+    * lang_should_branch can be made an argument: it takes the current step theorem
+    * and returns a term with the branch condition, with which you can split the
+    * path condition *)
+   (case lang_should_branch step_thm of
+     SOME (branch_cond_list, path_disj_thm) =>
+     (* Branch + prune *)
+     let
+      (* Get all path conditions in the shape of Cn /\ P ==> P /\ Cn *)
+      (* TODO: Why this tautological shape? Why store path_cond as a theorem and not a term? *)
+      val new_path_conds = map (CONJ path_cond o ASSUME) branch_cond_list
+
+      (* Simplify: some path conditions will now take the shape Cn /\ P ==> Cn /\ P <=> F *)
+      (* TODO: This rule might also be a language parameter *)
+      val new_path_conds' = map (SIMP_RULE std_ss []) new_path_conds
+
+      (* TODO: OPTIMIZE: Check if branch results in just one new path - then we don't need to add
+       * a new node to the tree, just replace data in the existing one *)
+      val (npaths', new_path_elems) =
+       foldl
+        (fn (path_cond, (curr_path_id, curr_path_cond_list)) =>
+	 if Feq $ concl path_cond 
+	 then (curr_path_id, curr_path_cond_list)
+	 else (curr_path_id+1,
+               (* TODO: OPTIMIZE: Cons instead of append? will reverse order *)
+               (curr_path_cond_list@[(curr_path_id+1,
+                                      path_cond,
+                                      DISCH_CONJUNCTS_ALL $ REWRITE_RULE [path_cond] step_thm,
+                                      fuel-1)])))
+        (npaths, [])
+        new_path_conds'
+
+      (* TODO: Using TRUTH as a placeholder - use thm option type in path_tree instead? *)
+      val new_path_nodes = map (fn (a,b,c,d) => node (a, TRUTH, [])) new_path_elems
+
+      val new_path_tree = insert_nodes path_tree (path_id, path_disj_thm, new_path_nodes)
+     in
+      symb_exec' (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) npaths'
+                  new_path_tree (t@new_path_elems) finished_list
+     end
+    | NONE =>
+     (* Do not branch - compute one regular step *)
+     let
+      val next_step_thm =
+       lang_regular_step (path_cond, step_thm)
+     in
+      if lang_is_finished next_step_thm
+      then
+       symb_exec' (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) npaths
+                  path_tree t (finished_list@[(path_id, path_cond, next_step_thm)])
+      else
+       symb_exec' (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) npaths
+                  path_tree (t@[(path_id, path_cond, next_step_thm, fuel-1)]) finished_list
+     end)
+in
+fun symb_exec (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) path_cond fuel =
+ symb_exec' (lang_regular_step, lang_init_step_thm, lang_should_branch, lang_is_finished) 1
+            (node (1, TRUTH, [])) [(1, path_cond, lang_init_step_thm, fuel)] []
+end;
+
+end

--- a/hol/symb_exec/symb_execLib.sml
+++ b/hol/symb_exec/symb_execLib.sml
@@ -35,12 +35,24 @@ fun insert_nodes path_tree (at_id, new_thm, new_nodes) =
 
 (* TODO: Rename "branch condition" to something else? Is this terminology OK? *)
 local
-(* Symbolic execution with branching on if-then-else
- * Width-first scheduling (positive case first) of execution
- * Note that branching consumes one step of (SML function) fuel
- * Here, the static ctxt and the dynamic path condition have been merged.
- * Currently, the path condition is stripped down as much as possible from p4-specific stuff
- * (another design priority could be legibility and keeping the connection to the P4 constructs). *)
+(* Generic symbolic execution
+ * This has four language-specific parameters:
+ *
+ * lang_regular_step (thm * thm -> thm): Takes one regular step in the language lang
+ *   (takes a path condition in theorem form and a step theorem and transforms it into
+ *    a new step theorem)
+ *
+ * lang_init_step_thm (thm): Step theorem for zero steps
+ *
+ * lang_should_branch (thm -> (term list * thm) option): Decides whether to branch
+ * by looking at the current step theorem. Returns NONE if branching should not
+ * happen, and a list of different branch conditions (used to update the path conditions)
+ * and a disjunction theorem stating that the disjunction of the branch conditions holds.
+
+ * lang_is_finished (thm -> bool): Decides whether symbolic execution should continue
+ * on this path by looking at the current step theorem.
+ *
+ * Note that branching consumes one step of (SML function) fuel *)
 fun symb_exec' lang_funs npaths path_tree [] finished_list = (path_tree, finished_list)
   | symb_exec' lang_funs npaths path_tree ((path_id, path_cond, step_thm, 0)::t) finished_list =
    symb_exec' lang_funs npaths path_tree t (finished_list@[(path_id, path_cond, step_thm)])

--- a/hol/symb_exec/symb_execScript.sml
+++ b/hol/symb_exec/symb_execScript.sml
@@ -31,7 +31,7 @@ Q.PAT_X_ASSUM ‘!h. h \/ disj_list (A ++ B) <=> disj_list (B ++ h::A)’ (fn th
 metis_tac[]
 QED
 
-Theorem disj_list_REWR2:
+Theorem disj_list_REWR:
  !a b B C.
  (((a \/ b) \/ disj_list C) <=> (b \/ disj_list (C++[a]))) /\
  ((a \/ disj_list B) <=> (disj_list (B++[a]))) /\
@@ -42,7 +42,7 @@ fs[disj_list_def] >>
 metis_tac[]
 QED
 
-Theorem disj_list_REWR3:
+Theorem disj_list_imp_REWR:
  !P a b B C.
  ((P ==> ((a \/ b) \/ disj_list C)) <=> (P ==> (b \/ disj_list (C++[a])))) /\
  ((P ==> (a \/ disj_list B)) <=> (P ==> (disj_list (B++[a])))) /\
@@ -51,7 +51,7 @@ Proof
 Cases_on ‘P’ >> (
   fs[]
 ) >>
-fs[disj_list_REWR2]
+fs[disj_list_REWR]
 QED
 
 Theorem imp_REWR:

--- a/hol/symb_exec/symb_execScript.sml
+++ b/hol/symb_exec/symb_execScript.sml
@@ -1,0 +1,14 @@
+open HolKernel boolLib liteLib simpLib Parse bossLib;
+
+val _ = new_theory "symb_exec";
+
+Theorem symb_exec_add_postcond:
+!P f s s' Q.
+(P ==> f s = SOME s') ==>
+Q s' ==>
+(P ==> f s = SOME s' /\ Q s')
+Proof
+metis_tac []
+QED
+
+val _ = export_theory ();

--- a/hol/symb_exec/symb_execScript.sml
+++ b/hol/symb_exec/symb_execScript.sml
@@ -11,4 +11,54 @@ Proof
 metis_tac []
 QED
 
+Definition disj_list_def:
+(* (disj_list (h::[]) = h) /\ *)
+ (disj_list (h::t) = (h \/ disj_list t)) /\
+ (disj_list [] = F)
+End
+
+Theorem disj_list_COMM:
+ !A B.
+ (disj_list (A++B) <=> disj_list (B++A))
+Proof
+Induct_on ‘A’ >> Induct_on ‘B’ >> (
+ fs[disj_list_def]
+) >>
+rpt strip_tac >>
+Q.PAT_ASSUM ‘!B. disj_list (A ++ B) <=> disj_list (B ++ A)’ (fn thm => REWRITE_TAC [thm]) >>
+fs[disj_list_def] >>
+Q.PAT_X_ASSUM ‘!h. h \/ disj_list (A ++ B) <=> disj_list (B ++ h::A)’ (fn thm => REWRITE_TAC [GSYM thm]) >>
+metis_tac[]
+QED
+
+Theorem disj_list_REWR2:
+ !a b B C.
+ (((a \/ b) \/ disj_list C) <=> (b \/ disj_list (C++[a]))) /\
+ ((a \/ disj_list B) <=> (disj_list (B++[a]))) /\
+ ((a \/ b) <=> (b \/ disj_list [a]))
+Proof
+ONCE_REWRITE_TAC[disj_list_COMM] >>
+fs[disj_list_def] >>
+metis_tac[]
+QED
+
+Theorem disj_list_REWR3:
+ !P a b B C.
+ ((P ==> ((a \/ b) \/ disj_list C)) <=> (P ==> (b \/ disj_list (C++[a])))) /\
+ ((P ==> (a \/ disj_list B)) <=> (P ==> (disj_list (B++[a])))) /\
+ ((P ==> (a \/ b)) <=> (P ==> (b \/ disj_list [a])))
+Proof
+Cases_on ‘P’ >> (
+  fs[]
+) >>
+fs[disj_list_REWR2]
+QED
+
+Theorem imp_REWR:
+ !P.
+ P <=> (T ==> P)
+Proof
+fs[]
+QED
+
 val _ = export_theory ();

--- a/ott/p4_sem.ott
+++ b/ott/p4_sem.ott
@@ -1564,15 +1564,6 @@ val get_word_binpred_def = Define `
 /\  (get_word_binpred binop_eq = (\w1 w2. w1 = w2))
 `;
 
-val get_word_binpred_def = Define `
-    (get_word_binpred binop_le = word_ls)
-/\  (get_word_binpred binop_ge = word_hs)
-/\  (get_word_binpred binop_lt = word_lo)
-/\  (get_word_binpred binop_gt = word_hi)
-/\  (get_word_binpred binop_neq = (\w1 w2. ~(w1 = w2)))
-/\  (get_word_binpred binop_eq = (\w1 w2. w1 = w2))
-`;
-
 val bitv_binpred_inner_def = Define `
     (bitv_binpred_inner binpred v v' 1 = SOME (((get_word_binpred binpred) ((v2w v): 1 word) ((v2w v'): 1 word)):boolv) )
 /\  (bitv_binpred_inner binpred v v' 2 = SOME (((get_word_binpred binpred) ((v2w v): 2 word) ((v2w v'): 2 word)):boolv) )


### PR DESCRIPTION
`symb_exec` now contains a basic symbolic execution mechanism for P4, split up into a generic and a P4-specific part. The symbolic execution can branch on conditional and transition statements. Pruning will be performed after every branch, and there is also the capability to merge all paths to obtain a contract.

`symb_exec` also contains a few tailor-made test cases to validate the symbolic execution.