### PR TITLE
Update to Poly/ML 5.9.2 and trindemossen-2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         polyml: ['5.7.1', '5.9.2']
-        hol4: ['trindemossen-1']
+        hol4: ['trindemossen-2']
 
     env:
       CACHE_DIR: /home/runner/cache

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        polyml: ['5.7.1', '5.9.1']
+        polyml: ['5.7.1', '5.9.2']
         hol4: ['trindemossen-1']
 
     env:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,11 +34,11 @@ First, navigate to the directory where you want to put the source code of Poly/M
 
 		sudo apt-get install build-essential git
 
-2. Install Poly/ML 5.9.1
+2. Install Poly/ML 5.9.2
 
 		git clone https://github.com/polyml/polyml.git
 		cd polyml
-		git checkout v5.9.1
+		git checkout v5.9.2
 		./configure --prefix=/usr
 		make
 		sudo make install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,11 +44,11 @@ First, navigate to the directory where you want to put the source code of Poly/M
 		sudo make install
 		cd ..
 
-3. Install HOL4 Trindemossen-1
+3. Install HOL4 Trindemossen-2
 
 		git clone https://github.com/HOL-Theorem-Prover/HOL.git
 		cd HOL
-		git checkout trindemossen-1
+		git checkout trindemossen-2
 		poly < tools/smart-configure.sml
 		bin/build
 		cd ..

--- a/hol/ottLib.sml
+++ b/hol/ottLib.sml
@@ -76,7 +76,7 @@ in
   HO_MATCH_MP_TAC list_induction THEN STRIP_TAC THENL 
   [ALL_TAC, STRIP_TAC THEN STRIP_TAC THEN PAIR_CASES_TAC] THEN
   SRW_TAC [] [] THEN 
-  CONV_TAC TotalDefn.TC_SIMP_CONV THEN 
+  TotalDefn.TC_SIMP_TAC std_ss [] THEN 
   SRW_TAC [] [] THEN
   RES_TAC THEN
   DECIDE_TAC THEN NO_TAC
@@ -84,7 +84,7 @@ end;
 
 fun ONE_TERM_TAC measure =
   WF_REL_TAC `^measure` THEN
-  CONV_TAC TotalDefn.TC_SIMP_CONV THEN  
+  TotalDefn.TC_SIMP_TAC std_ss [] THEN  
   SRW_TAC [] [] THEN
   APPLY_FILTER_SIZE THEN 
   TRY (ASSUM_LIST (MAP_FIRST MEM_IND_TAC o List.filter is_mem o List.map concl))

--- a/hol/p4_auxScript.sml
+++ b/hol/p4_auxScript.sml
@@ -7,7 +7,7 @@ open pairTheory optionTheory arithmeticTheory;
 open p4Theory;
 
 (* OPTION_BIND as infix *)
-Definition app_opt_def:
+Definition app_opt_def[simp]:
  $>>= x_opt f =
   OPTION_BIND x_opt f
 End
@@ -1335,7 +1335,6 @@ Theorem  EL_relation_to_INDEX_lesseq:
             i <= LENGTH l ==>
             m = n 
 Proof
-
 Induct >>
 REPEAT STRIP_TAC >>
 fs[INDEX_FIND_def] >>
@@ -1464,32 +1463,23 @@ Theorem index_find_concat1:
 ! l1 l2 n P.
 INDEX_FIND 0 P l1 = NONE  /\
 INDEX_FIND 0 P (l2 ⧺ l1) = SOME n ==>
-INDEX_FIND 0 P (l2) = SOME n 
+INDEX_FIND 0 P (l2) = SOME n
 Proof
 Induct_on `l1` >>
 Induct_on `l2` >>
-fs[INDEX_FIND_def] >>
-REPEAT STRIP_TAC >>
-CASE_TAC >| [
- rfs[]
- ,
- Cases_on `P h'` >| [
-  gvs[]
-  ,
-  gvs[] >>
-
-  ASSUME_TAC P_hold_on_next>> 
-  FIRST_X_ASSUM
-  (STRIP_ASSUME_TAC o (Q.SPECL [`0`,`(l2 ⧺ h'::l1)`,`P`,`n`])) >>
-  gvs[GSYM ADD1] >> 
-  RES_TAC >>
-  gvs[] >>
-
-  IMP_RES_TAC P_implies_next >>
-  Cases_on `n` >>
-  fs[]
-  ]
- ]
+gs[INDEX_FIND_def, AllCaseEqs()] >>
+REPEAT STRIP_TAC >> (
+ gs[]
+) >>
+ASSUME_TAC P_hold_on_next >> 
+FIRST_X_ASSUM
+ (STRIP_ASSUME_TAC o (Q.SPECL [`0`,`(l2 ⧺ h'::l1)`,`P`,`n`])) >>
+gvs[GSYM ADD1] >> 
+RES_TAC >>
+gvs[] >>
+IMP_RES_TAC P_implies_next >>
+Cases_on `n` >>
+fs[]
 QED
 
 
@@ -1835,17 +1825,16 @@ QED
 Theorem index_find_not_mem:
  ! l P e n. (INDEX_FIND n P l = NONE) /\ P e ==> ~ MEM e l 
 Proof
-
 Induct >>
 fs[INDEX_FIND_def] >>
 REPEAT GEN_TAC >>
-CASE_TAC >>
+gs[AllCaseEqs()] >>
 STRIP_TAC >>
-FIRST_X_ASSUM (STRIP_ASSUME_TAC o (Q.SPECL
-[`P`, `e` , `SUC n`])) >>
+FIRST_X_ASSUM (STRIP_ASSUME_TAC o (Q.SPECL [`P`, `e` , `SUC n`])) >>
 IMP_RES_TAC P_NONE_hold2 >>
-Cases_on `e=h` >>
-fs[]
+Cases_on `e=h` >> (
+ fs[]
+)
 QED
 
 
@@ -2573,8 +2562,6 @@ Definition deparameterise_tau_def:
   deparameterise_tau p_tau >>=
   \tau. deparameterise_x_taus t >>=
   \tau_l. SOME ((name, tau)::tau_l))
-Termination
-WF_REL_TAC `measure ( \ t. case t of | (INL p_tau) => p_tau_size p_tau | (INR p_tau_list) => p_tau1_size p_tau_list)`
 End
 
 Definition deparameterise_taus_def:
@@ -2594,8 +2581,6 @@ Definition parameterise_tau_def:
   | tau_ext => p_tau_ext "") /\
 (parameterise_x_taus [] = []) /\
 (parameterise_x_taus ((name, tau)::t) = ((name, parameterise_tau tau)::(parameterise_x_taus t)))
-Termination
-WF_REL_TAC `measure ( \ t. case t of | (INL tau) => tau_size tau | (INR tau_list) => tau1_size tau_list)`
 End
 
 Definition parameterise_taus_def:

--- a/hol/p4_coreScript.sml
+++ b/hol/p4_coreScript.sml
@@ -183,8 +183,6 @@ Definition set_fields_def:
       | NONE => NONE)
     | NONE => NONE)
   | _ => NONE)
-Termination
-WF_REL_TAC `measure ( \ (t, acc, packet_in). v1_size t)`
 End
 
 Definition set_header_def:
@@ -389,8 +387,6 @@ Definition header_entries2v_def:
   | (v_header validity x_v_l) => header_entries2v x_v_l
   | _ => NONE
  )
-Termination
-WF_REL_TAC `measure ( \ t. case t of | (INL x_v_l) => v1_size x_v_l | (INR (x,v)) => v_size v)`
 End
 
 

--- a/hol/p4_e_progressScript.sml
+++ b/hol/p4_e_progressScript.sml
@@ -629,7 +629,7 @@ IMP_RES_TAC bit_range >>
 fs[] >>
 
 fs[bitv_binop_def] >>
-RW.ONCE_RW_TAC [bitv_binop_inner_def] >>
+ONCE_REWRITE_TAC [bitv_binop_inner_def] >>
 fs[] >>
 srw_tac [numSimps.SUC_FILTER_ss][] 
 );
@@ -663,7 +663,7 @@ RES_TAC >>
 gvs[NOT_CLAUSES] >>
 
 fs[bitv_binop_def] >>
-RW.ONCE_RW_TAC [bitv_binop_inner_def] >>
+ONCE_REWRITE_TAC [bitv_binop_inner_def] >>
 fs[] >>
 srw_tac [numSimps.SUC_FILTER_ss][] 
 );
@@ -698,7 +698,7 @@ RES_TAC >>
 gvs[NOT_CLAUSES] >>
 
 fs[] >>
-RW.ONCE_RW_TAC [bitv_binpred_inner_def] >>
+ONCE_REWRITE_TAC [bitv_binpred_inner_def] >>
 fs[] >>
 srw_tac [numSimps.SUC_FILTER_ss][]
 );

--- a/hol/p4_from_json/parse_jsonScript.sml
+++ b/hol/p4_from_json/parse_jsonScript.sml
@@ -159,14 +159,6 @@ Definition json_to_string_def:
   (mem_to_string n_obj = let (n, obj) = n_obj in
        [CONCAT ["\""; n; "\""]]
        ++ [":"] ++ json_to_string obj)
-Termination
-   WF_REL_TAC `measure (\x. case x of
-       | INL obj => json_size obj
-       | INR p => json2_size p)`
-  >> rw[]
-  >> imp_res_tac json_size_MEM1
-  >> imp_res_tac json_size_MEM2
-  >> fs[]
 End
 
 (* lexing *)
@@ -582,14 +574,6 @@ Definition json_to_tok_def:
   /\
   (mem_to_tok n_obj = let (n, obj) = n_obj in
         json_to_tok obj ++ [COLON;Str n])
-Termination
-   WF_REL_TAC `measure (\x. case x of
-       | INL obj => json_size obj
-       | INR p => json2_size p)`
-  >> rw[]
-  >> imp_res_tac json_size_MEM1
-  >> imp_res_tac json_size_MEM2
-  >> fs[]
 End
 
 (*

--- a/hol/p4_from_json/petr4_to_hol4p4Script.sml
+++ b/hol/p4_from_json/petr4_to_hol4p4Script.sml
@@ -393,20 +393,16 @@ Triviality json_parse_obj_size:
 Proof
 Induct_on ‘json_list’ >- (
  rpt strip_tac >>
- fs[json_parse_obj_def, json_dest_obj_def, app_opt_def] >>
+ gs[json_parse_obj_def, json_dest_obj_def] >>
  Cases_on ‘json’ >> (fs[json_size_def])
 ) >>
 rpt strip_tac >>
-fs[json_parse_obj_def, app_opt_def] >>
-Cases_on ‘json’ >> (fs[json_dest_obj_def]) >>
-rw[] >>
-Cases_on ‘str_list’ >> (fs[json_parse_obj'_def, json_size_def]) >>
-(Cases_on ‘l’ >> (fs[json_parse_obj'_def, json_size_def])) >>
-
-Cases_on ‘h''’ >> (fs[json_parse_obj'_def, json_size_def, app_opt_def]) >>
-Cases_on ‘json_parse_obj' t t'’ >> (fs[json_parse_obj'_def, json_size_def]) >>
-rw[] >>
-subgoal ‘(case (Object t') of
+gs[json_parse_obj_def] >>
+Cases_on ‘str_list’ >> (Cases_on ‘x’ >> (gs[json_parse_obj'_def, json_size_def])) >>
+PairCases_on ‘h''’ >>
+gvs[json_parse_obj'_def, json_size_def] >>
+Cases_on ‘json’ >> (gvs[json_dest_obj_def]) >>
+subgoal ‘?x. (case (Object t') of
                 Object obj => SOME obj
               | Array v8 => NONE
               | String v9 => NONE
@@ -414,12 +410,19 @@ subgoal ‘(case (Object t') of
               | Bool v13 => NONE
               | Null => NONE) =
              SOME t'’ >- (
- fs[]
+ gs[]
 ) >>
-subgoal ‘json3_size json_list < json_size (Object t')’ >- (
- metis_tac[]
-) >>
-fs[json_size_def]
+res_tac >>
+gs[]
+QED
+
+Theorem list_size_json3:
+!json_list.
+list_size json_size json_list = json3_size json_list
+Proof
+Induct >> (
+ gs[list_size_def, json_size_def]
+)
 QED
 
 (* Parses compile-time known constants, e.g. in bitstring widths *)
@@ -1227,24 +1230,24 @@ Definition petr4_parse_expression_gen_def:
   | SOME_msg (SetExp e) => get_error_msg "set expression in unsupported location: " h1
   | NONE_msg exp_msg => NONE_msg ("could not parse expression: "++exp_msg))
 Termination
-WF_REL_TAC `measure ( \ t. case t of
+WF_REL_TAC ‘measure ( \ t. case t of
                            | (INL (maps, json, p_tau_opt)) => json_size json
                            | (INR $ INL (maps, json_list)) => json_p_tau_opt_list_size json_list
-                           | (INR $ INR (maps, json_list)) => json_p_tau_opt_list_size json_list)` >>
-fs[json_p_tau_opt_list_size_def] >>
-rpt strip_tac >> (fs[json_size_def]) >- (
- subgoal ‘?l1 l2. UNZIP t = (l1, l2)’ >- (fs[UNZIP_MAP]) >>
- fs []
+                           | (INR $ INR (maps, json_list)) => json_p_tau_opt_list_size json_list)’ >>
+gs[json_p_tau_opt_list_size_def] >>
+rpt strip_tac >> (gs[json_size_def]) >- (
+ gs[UNZIP_MAP]
 ) >- (
- subgoal ‘?l1 l2. UNZIP t = (l1, l2)’ >- (fs[UNZIP_MAP]) >>
- fs []
+ gs[UNZIP_MAP]
 ) >- (
- subgoal ‘?l1 l2. UNZIP t = (l1, l2)’ >- (fs[UNZIP_MAP]) >>
- fs []
+ gs[UNZIP_MAP]
 ) >- (
- subgoal ‘LENGTH args = LENGTH p_1'5'’ >- (imp_res_tac find_fty_match_args_LENGTH >> fs[]) >>
- fs[listTheory.UNZIP_ZIP]
-)
+ gs[list_size_json3]
+) >- (
+ gs[list_size_json3]
+) >>
+‘LENGTH args = LENGTH p_1'5'’ by (imp_res_tac find_fty_match_args_LENGTH >> gs[]) >>
+gs[UNZIP_MAP, listTheory.MAP_ZIP, list_size_json3]
 End
 
 (* TODO: Baking this into the above messes up the termination proof... *)
@@ -2282,25 +2285,48 @@ Definition petr4_parse_stmts_def:
     | NONE_msg msg' => NONE_msg msg')
   | NONE_msg msg => NONE_msg msg)
 Termination
-WF_REL_TAC `measure ( \ t. case t of | (INL (maps, json_list)) => json3_size json_list | (INR (maps, json_list_list)) => SUM (MAP (\ el . json3_size el + 1) json_list_list))` >>
+WF_REL_TAC ‘measure ( \ t. case t of | (INL (maps, json_list)) => json3_size json_list | (INR (maps, json_list_list)) => SUM (MAP (\ el . json3_size el + 1) json_list_list))’ >>
 rpt strip_tac >> (fs[json_size_def]) >- (
- fs[json_parse_obj_def, json_dest_obj_def, app_opt_def] >>
+ fs[json_parse_obj_def, json_dest_obj_def] >>
  Cases_on ‘p_2'’ >> (fs[]) >>
  rw[] >>
- Cases_on ‘l’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
- Cases_on ‘h’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
- Cases_on ‘t'’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
- Cases_on ‘h’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
+ Cases_on ‘l’ >> (fs[json_parse_obj'_def]) >>
+ Cases_on ‘h’ >> (fs[json_parse_obj'_def]) >>
+ Cases_on ‘t'’ >> (fs[json_parse_obj'_def]) >>
+ Cases_on ‘h’ >> (fs[json_parse_obj'_def]) >>
  Cases_on ‘q' = "annotations"’ >> (fs[]) >>
- Cases_on ‘t''’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
- Cases_on ‘h’ >> (fs[json_parse_obj'_def, app_opt_def]) >>
+ Cases_on ‘t''’ >> (fs[json_parse_obj'_def]) >>
+ Cases_on ‘h’ >> (fs[json_parse_obj'_def]) >>
  Cases_on ‘q'' = "statements"’ >> (fs[]) >>
- Cases_on ‘json_parse_obj' [] t'’ >> (fs[json_size_def, app_opt_def])
+ Cases_on ‘json_parse_obj' [] t'’ >> (fs[json_size_def]) >>
+
+ gvs[char_size_def] >>
+ ‘json3_size t +
+   (json_size annotations +
+    (json_size p_2 +
+     (json_size r +
+      (list_size json_size stmts +
+       (list_size (pair_size (list_size char_size) json_size) t' + 57))))) =
+   json3_size stmts + 1 +
+   json3_size t +
+   (json_size annotations +
+    (json_size p_2 +
+     (json_size r +
+      (list_size (pair_size (list_size char_size) json_size) t' + 56))))’ suffices_by (
+  gs[]
+ ) >>
+ gvs[] >>
+ ‘list_size json_size stmts = json3_size stmts’ by (
+  Induct_on ‘stmts’ >> (
+   fs[json_size_def, list_size_def]
+  )
+ ) >>
+ gs[]
 ) >- (
  (* Switch case *)
  IMP_RES_TAC petr4_parse_switch_cases_size >>
  res_tac >>
- fs[json_size_def, app_opt_def]
+ fs[json_size_def]
 )
 End
 

--- a/hol/p4_stmt_subject_reductionScript.sml
+++ b/hol/p4_stmt_subject_reductionScript.sml
@@ -2017,7 +2017,7 @@ gvs[type_scopes_list_def, similarl_def] >>
 REPEAT STRIP_TAC >>
 IMP_RES_TAC star_not_in_sl_normalization >>       
 SIMP_TAC list_ss [INDEX_FIND_def] >>
-CASE_TAC >| [
+conj_tac >| [
  IMP_RES_TAC type_scopes_list_normalize >>
  gvs[type_scopes_list_def, similarl_def] >>
  IMP_RES_TAC star_not_in_ts_similar >> gvs[]
@@ -2709,19 +2709,19 @@ STRIP_TAC >| [
                (STRIP_ASSUME_TAC o  SIMP_RULE (srw_ss()) [Once lval_typ_cases] ) >>
  gvs[] >>
       
- gvs[assign_def] >>
- Cases_on ‘v’ >> gvs[] >>               
- Cases_on ‘lookup_lval (scopest ⧺ gscope) l’ >> gvs[] >>
- Cases_on ‘x’ >> gvs[] >>               
- Cases_on ‘assign_to_slice p p' (e_v (v_bit bitv)) (e_v (v_bit bitv'))’ >> gvs[] >>
+ gs[assign_def] >>
+ Cases_on ‘v’ >> gs[] >>               
+ Cases_on ‘lookup_lval (scopest ⧺ gscope) l’ >> gs[] >>
+ Cases_on ‘x’ >> gs[] >>               
+ Cases_on ‘assign_to_slice p p' (e_v (v_bit bitv)) (e_v (v_bit bitv'))’ >> gs[] >>
          
  ASSUME_TAC lookup_SLICE_is_wt >>
- FIRST_X_ASSUM (STRIP_ASSUME_TAC o (Q.SPECL [`l`, ‘tslg’,‘T_e’, ‘tsl’,‘gscope’, ‘scopest’, ‘(w)’, ‘p'’])) >>
+ FIRST_X_ASSUM (STRIP_ASSUME_TAC o (Q.SPECL [‘l’, ‘tslg’,‘T_e’, ‘tsl’,‘gscope’, ‘scopest’, ‘(w)’, ‘p'’])) >>
  gvs[] >>
 
     
  FIRST_X_ASSUM (STRIP_ASSUME_TAC o (Q.SPECL
- [`scopest`, ‘tsl’,‘gscope’, ‘tslg’, ‘T_e’, ‘scopest'’, ‘gscope'’, ‘ (tau_bit w)’, ‘assigned_sl’, ‘x’])) >>
+ [‘scopest’, ‘tsl’,‘gscope’, ‘tslg’, ‘T_e’, ‘scopest'’, ‘gscope'’, ‘ (tau_bit w)’, ‘assigned_sl’, ‘x’])) >>
  gvs[] >>
 
  IMP_RES_TAC bit_slice_typed  >> gvs[]

--- a/hol/symb_exec/p4_bigstepScript.sml
+++ b/hol/symb_exec/p4_bigstepScript.sml
@@ -1,8 +1,8 @@
 open HolKernel boolLib liteLib simpLib Parse bossLib;
-open p4Theory p4_auxTheory p4_exec_semTheory;
 
 val _ = new_theory "p4_bigstep";
 
+open p4Theory p4_auxTheory p4_exec_semTheory;
 open listTheory;
 
 (* This file contains a big-step semantics for a fragment of P4 that
@@ -92,7 +92,7 @@ Definition bigstep_e_exec_def:
  (bigstep_e_exec scope_lists (INL (e_struct x_e_l)) n =
   case bigstep_e_exec scope_lists (INR (MAP SND x_e_l)) n of
   | SOME (INR $ e_l', n') =>
-   if (EVERY is_v e_l')
+   if EVERY is_v e_l'
    then
     SOME (INL $ e_v $ v_struct (ZIP (MAP FST x_e_l, vl_of_el e_l')) , n'+1)
    else
@@ -599,8 +599,8 @@ Theorem bigstep_e_exec_struct_REWR:
 bigstep_e_exec scope_lists (INL (e_struct x_e_l)) n = SOME (t',m) <=>
  ?e_l' n'.
  bigstep_e_exec scope_lists (INR (MAP SND x_e_l)) n = SOME (INR e_l', n') /\
- ((EVERY is_v e_l' /\ t' = (INL (e_v (v_struct (ZIP (MAP FST x_e_l,vl_of_el e_l'))))) /\ m = n' + 1) \/
-  (~(EVERY is_v e_l') /\ t' = (INL (e_struct (ZIP (MAP FST x_e_l,e_l')))) /\ m = n')
+ ((EVERY is_v e_l' /\ t' = (INL (e_v (v_struct (ZIP (MAP FST x_e_l, vl_of_el e_l'))))) /\ m = n' + 1) \/
+  (~(EVERY is_v e_l') /\ t' = (INL (e_struct (ZIP (MAP FST x_e_l, e_l')))) /\ m = n')
  )
 Proof
 rpt strip_tac >>
@@ -611,19 +611,35 @@ eq_tac >> (
 QED
 
 val bigstep_e_exec_ind_hyp_tac =
- PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+ PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  decide_tac
 ;
 
 val bigstep_e_exec_2_ind_hyp_tac =
- PAT_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
- PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+ PAT_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+ PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  decide_tac
 ;
+
+Theorem e3_size_list:
+!l.
+e3_size (MAP SND l) <
+ list_size (pair_size (list_size char_size) e_size) l + 1
+Proof
+Induct_on ‘l’ >> (
+ gs[e_size_def]
+) >>
+rpt strip_tac >>
+‘(e_size (SND h) + 1) < (pair_size (list_size char_size) e_size h + 1)’ by (
+ PairCases_on ‘h’ >>
+ gs[]
+) >>
+gs[]
+QED
 
 Theorem bigstep_e_exec_incr:
 !t n scope_lists t' m.
@@ -700,12 +716,18 @@ Induct_on ‘t’ >- (
   bigstep_e_exec_ind_hyp_tac,
 
   (* struct *)
-  gs[bigstep_e_exec_struct_REWR] >>
-  rpt strip_tac >> (
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
-   gs[e_size_def, e3_e1_size] >>
-   res_tac >>
-   decide_tac
+  gvs[bigstep_e_exec_struct_REWR] >> (
+   rpt strip_tac >> (
+    qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
+    gs[] >>
+    ‘e3_size (MAP SND l) <
+        list_size (pair_size (list_size char_size) e_size) l + 1’ by (
+     gs[e3_size_list]
+    ) >>
+    gs[e_size_def, e3_e1_size] >>
+    res_tac >>
+    decide_tac
+   )
   ),
 
   (* header *)
@@ -727,7 +749,7 @@ gs[] >>
 Cases_on ‘bigstep_e_exec scope_lists (INR y) x1’ >> (
  gs[]
 ) >- (
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ qpat_x_assum ‘!y'. _’ (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  decide_tac
@@ -736,14 +758,14 @@ PairCases_on ‘x'’ >>
 gs[] >>
 Cases_on ‘x'0’ >>
 gs[] >- (
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  decide_tac
 ) >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
 gs[e_size_def] >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR y)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INR y)’] thm)) >>
 gs[e_size_def] >>
 res_tac >>
 Cases_on ‘is_v x’ >> (
@@ -753,7 +775,7 @@ QED
 
 val bigstep_e_exec_unchanged_ind_hyp_tac =
  imp_res_tac bigstep_e_exec_incr >>
- PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+ PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  gs[]
@@ -761,8 +783,8 @@ val bigstep_e_exec_unchanged_ind_hyp_tac =
 
 val bigstep_e_exec_unchanged_2_ind_hyp_tac =
  imp_res_tac bigstep_e_exec_incr >>
- PAT_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
- PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+ PAT_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+ PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  gs[]
@@ -812,8 +834,8 @@ Induct_on ‘t’ >- (
    bigstep_e_exec_unchanged_2_ind_hyp_tac
   ) >- (
    imp_res_tac bigstep_e_exec_incr >>
-   PAT_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   PAT_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    fs[e_size_def] >>
    subgoal ‘n = n'’ >- (
     decide_tac
@@ -829,8 +851,8 @@ Induct_on ‘t’ >- (
    bigstep_e_exec_unchanged_2_ind_hyp_tac
   ) >- (
    imp_res_tac bigstep_e_exec_incr >>
-   PAT_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   PAT_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    fs[e_size_def] >>
    subgoal ‘n = n'’ >- (
     decide_tac
@@ -855,13 +877,18 @@ Induct_on ‘t’ >- (
   bigstep_e_exec_unchanged_ind_hyp_tac,
 
   (* struct *)
-  gs[bigstep_e_exec_struct_REWR] >> (
+  gvs[bigstep_e_exec_struct_REWR] >- (
    imp_res_tac bigstep_e_exec_incr >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
-   gs[e_size_def, e3_e1_size] >>
-   res_tac >>
-   gvs[GSYM ZIP_MAP_FST_SND]
-  ),
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
+   gs[e_size_def, e3_e1_size]
+  ) >>
+  imp_res_tac bigstep_e_exec_incr >>
+  qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
+  gs[e_size_def, e3_e1_size] >>
+  ‘e3_size (MAP SND l) <
+       list_size (pair_size (list_size char_size) e_size) l + 1’ by gs[e3_size_list] >>
+  res_tac >>
+  gvs[GSYM ZIP_MAP_FST_SND],
 
   (* header *)
   gs[bigstep_e_exec_def]
@@ -882,7 +909,7 @@ gs[] >>
 Cases_on ‘bigstep_e_exec scope_lists (INR y) x1’ >> (
  gs[]
 ) >- (
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  gs[]
@@ -891,19 +918,19 @@ PairCases_on ‘x'’ >>
 gs[] >>
 Cases_on ‘x'0’ >>
 gs[] >- (
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac >>
  gs[]
 ) >>
 imp_res_tac bigstep_e_exec_incr >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
 gs[e_size_def] >>
 PAT_ASSUM “!y'.
           (case y' of INL e => e_size e | INR e_l => e3_size e_l) <
           e3_size y + (e_size h + 1) ==>
           !t' scope_lists n.
-            bigstep_e_exec scope_lists y' n = SOME (t',n) ==> y' = t'” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR y)’] thm)) >>
+            bigstep_e_exec scope_lists y' n = SOME (t',n) ==> y' = t'” (fn thm => assume_tac (Q.SPECL [‘(INR y)’] thm)) >>
 fs[e_size_def] >>
 Cases_on ‘is_v x’ >> (
  gs[]
@@ -923,7 +950,7 @@ QED
 
 (* TODO: Revisit this *)
 fun bigstep_e_exec_not_eq_ind_hyp_tac tmq =
- PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+ PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
  fs[e_size_def] >>
  subgoal tmq >- (
   gs[]
@@ -1003,7 +1030,7 @@ Induct_on ‘t’ >- (
 
   (* struct *)
   gs[bigstep_e_exec_struct_REWR] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
   gs[e_size_def, e3_e1_size] >>
   imp_res_tac bigstep_e_exec_unchanged >>
   gvs[ZIP_MAP_FST_SND],
@@ -1028,7 +1055,7 @@ Cases_on ‘bigstep_e_exec scope_lists (INR y) x1’ >> (
  gs[]
 ) >- (
  gvs[] >>
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac
 ) >>
@@ -1037,18 +1064,18 @@ gs[] >>
 Cases_on ‘x'0’ >>
 gs[] >- (
  gvs[] >>
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  res_tac
 ) >>
 imp_res_tac bigstep_e_exec_incr >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
 gs[e_size_def] >>
 PAT_ASSUM “!y'.
           (case y' of INL e => e_size e | INR e_l => e3_size e_l) <
           e3_size y + (e_size h + 1) ==>
           !t'' scope_lists'.
-            y' <> t'' ==> bigstep_e_exec scope_lists' y' 0 <> SOME (t'',0)” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR y)’] thm)) >>
+            y' <> t'' ==> bigstep_e_exec scope_lists' y' 0 <> SOME (t'',0)” (fn thm => assume_tac (Q.SPECL [‘(INR y)’] thm)) >>
 gs[e_size_def] >>
 Cases_on ‘is_v x’ >> (
  gs[]
@@ -1125,6 +1152,31 @@ PairCases_on ‘x’ >>
 gs[]
 QED
 
+Theorem unred_mem_index_oEL:
+!e_l i.
+unred_mem_index e_l = SOME i ==>
+?e. oEL i e_l = SOME e
+Proof
+Induct >> (
+ gvs[unred_mem_index_def, unred_mem_def, INDEX_FIND_def, AllCaseEqs()]
+) >>
+rpt strip_tac >> (gvs[]) >> (
+ gs[oEL_def, AllCaseEqs()]
+) >>
+qpat_x_assum ‘!i. _’ (fn thm => assume_tac $ Q.SPECL [‘i-1’] thm) >>
+gs[] >>
+‘INDEX_FIND 0 (\e. ~is_const e) e_l = SOME (i-1, e)’ by (
+ FULL_SIMP_TAC bool_ss [arithmeticTheory.ONE] >>
+ FULL_SIMP_TAC bool_ss [p4_auxTheory.P_hold_on_next] >>
+ gs[]
+) >>
+gs[] >>
+qexists_tac ‘e'’ >> gs[] >>
+(* Silly contradiction on INDEX_FIND... *)
+strip_tac >>
+gs[listTheory.INDEX_FIND_add]
+QED
+
 Theorem bigstep_e_exec_sound:
 !t scope_list g_scope_list' t' e e_l apply_table_f (ext_map:'a ext_map) func_map b_func_map pars_map tbl_map.
 bigstep_e_exec (scope_list ++ g_scope_list') t 0 = SOME (t', 1) ==>
@@ -1157,19 +1209,15 @@ Induct_on ‘t’ >- (
   gs[bigstep_e_exec_var_REWR] >>
   gs[e_exec_def, lookup_vexp_def, lookup_vexp2_def] >>
   Cases_on ‘lookup_map (scope_list ++ g_scope_list') v’ >> (
-   gs[]
-  ) >>
-  PairCases_on ‘x’ >>
-  gs[],
+   gvs[AllCaseEqs()]
+  ),
 
   (* list *)
   gvs[bigstep_e_exec_def],
 
   (* acc *)
-  rw[] >>
-  gs[bigstep_e_exec_acc_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_acc_REWR] >> (
+   gvs[e_exec_def, AllCaseEqs()]
   ) >- (
    Cases_on ‘is_v x’ >> (
     gs[]
@@ -1181,7 +1229,7 @@ Induct_on ‘t’ >- (
    imp_res_tac bigstep_e_exec_unchanged >>
    gs[]
   ) >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   fs[] >>
@@ -1193,10 +1241,8 @@ Induct_on ‘t’ >- (
   ),
 
   (* unop *)
-  rw[] >>
-  gs[bigstep_e_exec_unop_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_unop_REWR] >> (
+   gvs[e_exec_def]
   ) >- (
    Cases_on ‘is_v x’ >> (
     gs[]
@@ -1209,7 +1255,7 @@ Induct_on ‘t’ >- (
    gs[]
   ) >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   fs[] >>
@@ -1221,10 +1267,8 @@ Induct_on ‘t’ >- (
   ),
 
   (* cast *)
-  rw[] >>
-  gs[bigstep_e_exec_cast_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_cast_REWR] >> (
+   gvs[e_exec_def]
   ) >- (
    Cases_on ‘is_v x’ >> (
     gs[]
@@ -1237,7 +1281,7 @@ Induct_on ‘t’ >- (
    gs[]
   ) >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   fs[] >>
@@ -1249,10 +1293,8 @@ Induct_on ‘t’ >- (
   ),
 
   (* binop *)
-  rw[] >>
-  gs[bigstep_e_exec_binop_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_binop_REWR] >> (
+   gvs[e_exec_def]
   ) >- (
    gs[] >>
    imp_res_tac bigstep_e_exec_unchanged >>
@@ -1283,7 +1325,7 @@ Induct_on ‘t’ >- (
      ) >>
      gs[bigstep_e_exec_def] >>
      gvs[] >>
-     PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+     PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
      gs[e_size_def] >>
      res_tac >>
      fs[]
@@ -1300,7 +1342,7 @@ Induct_on ‘t’ >- (
     gs[]
    ) >>
    gs[] >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    Cases_on ‘x’ >> (
     gvs[is_v_def]
    ) >> (
@@ -1312,7 +1354,7 @@ Induct_on ‘t’ >- (
    )
   ) >- (
    gs[] >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    fs[] >>
@@ -1322,10 +1364,8 @@ Induct_on ‘t’ >- (
   ),
 
   (* concat *)
-  rw[] >>
-  gs[bigstep_e_exec_concat_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_concat_REWR] >> (
+   gvs[e_exec_def]
   ) >- (
    gs[] >>
    imp_res_tac bigstep_e_exec_incr >>
@@ -1354,7 +1394,7 @@ Induct_on ‘t’ >- (
      gs[bigstep_e_exec_def]
     ) >>
     gs[] >>
-    PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+    PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
     gs[e_size_def] >>
     res_tac >>
     fs[] >>
@@ -1372,7 +1412,7 @@ Induct_on ‘t’ >- (
     gs[]
    ) >>
    gs[] >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    fs[] >>
@@ -1380,7 +1420,7 @@ Induct_on ‘t’ >- (
    gs[]
   ) >- (
    gs[] >>
-   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    fs[] >>
@@ -1394,10 +1434,8 @@ Induct_on ‘t’ >- (
   ),
 
   (* slice *)
-  rw[] >>
-  gs[bigstep_e_exec_slice_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_slice_REWR] >> (
+   gvs[e_exec_def]
   ) >- (
    Cases_on ‘is_v_bit x’ >> (
     gs[]
@@ -1410,7 +1448,7 @@ Induct_on ‘t’ >- (
    gs[]
   ) >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   fs[] >>
@@ -1425,10 +1463,8 @@ Induct_on ‘t’ >- (
   gvs[bigstep_e_exec_def],
 
   (* select *)
-  rw[] >>
-  gs[bigstep_e_exec_select_REWR] >> (
-   rw[] >>
-   gs[e_exec_def]
+  gvs[bigstep_e_exec_select_REWR] >> (
+   gvs[e_exec_def]
   ) >>
   Cases_on ‘is_v x’ >> (
    gs[]
@@ -1437,7 +1473,7 @@ Induct_on ‘t’ >- (
     gs[is_v_def, bigstep_e_exec_def]
    )
   ) >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   fs[],
@@ -1460,7 +1496,7 @@ Induct_on ‘t’ >- (
   ) >>
   gs[] >>
   PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR (MAP SND (l:(string # e) list)))’] thm)) >>
-  gs[e_size_def, e3_e1_size] >>
+  gs[e_size_def, e3_e1_size, e3_size_list] >>
   res_tac >>
   PAT_X_ASSUM “!tbl_map pars_map func_map ext_map b_func_map apply_table_f. _” (fn thm => ASSUME_TAC (Q.SPECL [‘tbl_map’, ‘pars_map’, ‘func_map’, ‘ext_map’, ‘b_func_map’, ‘apply_table_f’] thm)) >>
   Cases_on ‘l’ >- (
@@ -1485,7 +1521,7 @@ Induct_on ‘y’ >> (
   gs[] >>
   imp_res_tac bigstep_e_exec_unchanged >>
   gs[] >>
-  PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR y)’] thm)) >>
+  PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INR y)’] thm)) >>
   fs[e_size_def] >>
   subgoal ‘e3_size y < e3_size e_l’ >- (
    gvs[e_size_def]
@@ -1501,7 +1537,6 @@ Induct_on ‘y’ >> (
   qexists_tac ‘i+1’ >>
   gvs[] >>
   rpt strip_tac >- (
-   (* Not true? h could be any expression that is not reduced further.. *)
    subgoal ‘is_const h’ >- (
     Cases_on ‘h’ >> (
      gs[is_v_def, is_const_def]
@@ -1529,7 +1564,7 @@ Induct_on ‘y’ >> (
    gs[is_const_def, bigstep_e_exec_def]
   )
  ) >>
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  fs[e_size_def] >>
  res_tac >>
  fs[] >>
@@ -1548,7 +1583,7 @@ subgoal ‘~is_const h’ >- (
  )
 ) >>
 gs[unred_mem_index_def, unred_mem_def, INDEX_FIND_def, LUPDATE_def] >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
 fs[e_size_def] >>
 res_tac >>
 fs[]
@@ -1600,13 +1635,13 @@ Definition e_multi_exec'_list_def:
  (e_multi_exec'_list (ctx:'a ctx) g_scope_list scope_list (h::t) (SUC fuel) =
   if is_v h
   then
-   (case e_multi_exec'_list (ctx:'a ctx) g_scope_list scope_list t (SUC fuel) of
+   (case e_multi_exec'_list ctx g_scope_list scope_list t (SUC fuel) of
     | SOME t' => SOME (h::t')
     | NONE => NONE)
   else
    (case e_multi_exec'_count ctx g_scope_list scope_list h (SUC fuel) of
     | SOME (h', fuel_spent) =>
-     (case e_multi_exec'_list (ctx:'a ctx) g_scope_list scope_list t ((SUC fuel)-fuel_spent) of
+     (case e_multi_exec'_list ctx g_scope_list scope_list t ((SUC fuel)-fuel_spent) of
       | SOME t' => SOME (h'::t')
       | NONE => NONE)
     | _ => NONE))
@@ -1618,7 +1653,7 @@ Definition e_multi_exec'_list'_def:
  (e_multi_exec'_list' _ _ _ e_l 0 = SOME e_l)
  /\
  (e_multi_exec'_list' (ctx:'a ctx) g_scope_list scope_list e_l (SUC fuel) =
-  case e_multi_exec'_list' (ctx:'a ctx) g_scope_list scope_list e_l fuel of
+  case e_multi_exec'_list' ctx g_scope_list scope_list e_l fuel of
   | SOME e_l' =>
    (case unred_mem_index e_l' of
     | SOME i =>
@@ -1650,7 +1685,7 @@ Theorem bigstep_e_acc_exec_sound_n_not_v:
 !ctx g_scope_list' scope_list e e' n f.
 ~is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list e n = SOME e' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list (e_acc e f) n = SOME (e_acc e' f)
+e_multi_exec' ctx g_scope_list' scope_list (e_acc e f) n = SOME (e_acc e' f)
 Proof
 Induct_on ‘n’ >- (
  gs[e_multi_exec'_def]
@@ -1668,7 +1703,7 @@ Theorem bigstep_e_acc_exec_sound_n_v:
 !ctx g_scope_list' scope_list e e' n f.
 is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list e n = SOME e' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list (e_acc e f) (SUC n) = e_exec_acc (e_acc e' f)
+e_multi_exec' ctx g_scope_list' scope_list (e_acc e f) (SUC n) = e_exec_acc (e_acc e' f)
 Proof
 Induct_on ‘n’ >- (
  rpt strip_tac >>
@@ -1726,7 +1761,7 @@ Theorem bigstep_e_unop_exec_sound_n_not_v:
 !ctx g_scope_list scope_list e e' n unop.
 ~is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e n = SOME e' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_unop unop e) n = SOME (e_unop unop e')
+e_multi_exec' ctx g_scope_list scope_list (e_unop unop e) n = SOME (e_unop unop e')
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1743,7 +1778,7 @@ Theorem bigstep_e_unop_exec_sound_n_v:
 is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e n = SOME e' ==>
 e_exec_unop unop e' = SOME v ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_unop unop e) (SUC n) = SOME (e_v v)
+e_multi_exec' ctx g_scope_list scope_list (e_unop unop e) (SUC n) = SOME (e_v v)
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1758,7 +1793,7 @@ Theorem bigstep_e_cast_exec_sound_n_not_v:
 !ctx g_scope_list scope_list e e' n cast.
 ~is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e n = SOME e' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_cast cast e) n = SOME (e_cast cast e')
+e_multi_exec' ctx g_scope_list scope_list (e_cast cast e) n = SOME (e_cast cast e')
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1775,7 +1810,7 @@ Theorem bigstep_e_cast_exec_sound_n_v:
 is_v e' ==>
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e n = SOME e' ==>
 e_exec_cast cast e' = SOME v ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_cast cast e) (SUC n) = SOME (e_v v)
+e_multi_exec' ctx g_scope_list scope_list (e_cast cast e) (SUC n) = SOME (e_v v)
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1789,7 +1824,7 @@ QED
 Theorem bigstep_e_binop_exec_sound_n_first:
 !ctx g_scope_list scope_list e1 e1' e2 binop n.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_binop e1 binop e2) n = SOME (e_binop e1' binop e2)
+e_multi_exec' ctx g_scope_list scope_list (e_binop e1 binop e2) n = SOME (e_binop e1' binop e2)
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1807,9 +1842,8 @@ Theorem bigstep_e_binop_exec_sound_n_first_shortcircuit:
 !ctx g_scope_list scope_list e e' binop v n.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e n = SOME (e_v v) ==>
 is_short_circuitable binop ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_binop e binop e')
-          (SUC n) =
-        e_exec_short_circuit v binop e'
+e_multi_exec' ctx g_scope_list scope_list (e_binop e binop e')
+ (SUC n) = e_exec_short_circuit v binop e'
 Proof
 Induct_on ‘n’ >- (
  rpt strip_tac >>
@@ -1864,9 +1898,9 @@ Theorem bigstep_e_binop_exec_sound_n_second:
 !ctx g_scope_list scope_list e1 e1' e2 e2' binop n n'.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
 is_v e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e2 n' = SOME e2' ==>
+e_multi_exec' ctx g_scope_list scope_list e2 n' = SOME e2' ==>
 ~is_short_circuitable binop ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_binop e1 binop e2)
+e_multi_exec' ctx g_scope_list scope_list (e_binop e1 binop e2)
            (n' + n) = SOME (e_binop e1' binop e2')
 Proof
 Induct_on ‘n'’ >> (
@@ -1911,11 +1945,11 @@ Theorem bigstep_e_binop_exec_sound_n_both:
 !ctx g_scope_list scope_list e1 e1' e2 e2' binop v n n' n''.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
 is_v e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e2 n' = SOME e2' ==>
+e_multi_exec' ctx g_scope_list scope_list e2 n' = SOME e2' ==>
 is_v e2' ==>
 ~is_short_circuitable binop ==>
 e_exec_binop e1' binop e2' = SOME v ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_binop e1 binop e2)
+e_multi_exec' ctx g_scope_list scope_list (e_binop e1 binop e2)
           (SUC (n' + n)) = SOME (e_v v)
 Proof
 rpt strip_tac >>
@@ -1930,7 +1964,7 @@ QED
 Theorem bigstep_e_concat_exec_sound_n_first:
 !ctx g_scope_list scope_list e1 e1' e2 n.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_concat e1 e2) n = SOME (e_concat e1' e2)
+e_multi_exec' ctx g_scope_list scope_list (e_concat e1 e2) n = SOME (e_concat e1' e2)
 Proof
 Induct_on ‘n’ >> (
  gs[e_multi_exec'_def, e_exec_def, AllCaseEqs()]
@@ -1949,8 +1983,8 @@ Theorem bigstep_e_concat_exec_sound_n_second:
 !ctx g_scope_list scope_list e1 e1' e2 e2' n n'.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
 is_v_bit e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e2 n' = SOME e2' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_concat e1 e2)
+e_multi_exec' ctx g_scope_list scope_list e2 n' = SOME e2' ==>
+e_multi_exec' ctx g_scope_list scope_list (e_concat e1 e2)
            (n' + n) = SOME (e_concat e1' e2')
 Proof
 Induct_on ‘n'’ >> (
@@ -1998,10 +2032,10 @@ Theorem bigstep_e_concat_exec_sound_n_both:
 !ctx g_scope_list scope_list e1 e1' e2 e2' v n n' n''.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
 is_v_bit e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e2 n' = SOME e2' ==>
+e_multi_exec' ctx g_scope_list scope_list e2 n' = SOME e2' ==>
 is_v_bit e2' ==>
 e_exec_concat e1' e2' = SOME v ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_concat e1 e2)
+e_multi_exec' ctx g_scope_list scope_list (e_concat e1 e2)
           (SUC (n' + n)) = SOME (e_v v)
 Proof
 rpt strip_tac >>
@@ -2018,7 +2052,7 @@ Theorem bigstep_e_slice_exec_sound_n_first:
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
 is_v_bit e2 ==>
 is_v_bit e3 ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_slice e1 e2 e3)
+e_multi_exec' ctx g_scope_list scope_list (e_slice e1 e2 e3)
           n = SOME (e_slice e1' e2 e3)
 Proof
 Induct_on ‘n’ >> (
@@ -2052,7 +2086,7 @@ is_v_bit e1' ==>
 is_v_bit e2 ==>
 is_v_bit e3 ==>
 e_exec_slice e1' e2 e3 = SOME v ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_slice e1 e2 e3)
+e_multi_exec' ctx g_scope_list scope_list (e_slice e1 e2 e3)
           (SUC n) = SOME (e_v v)
 Proof
 Induct_on ‘n’ >- (
@@ -2103,7 +2137,7 @@ QED
 Theorem bigstep_e_select_exec_sound_n_first:
 !ctx g_scope_list scope_list e1 e1' cases default n.
 e_multi_exec' (ctx:'a ctx) g_scope_list scope_list e1 n = SOME e1' ==>
-e_multi_exec' (ctx:'a ctx) g_scope_list scope_list (e_select e1 cases default)
+e_multi_exec' ctx g_scope_list scope_list (e_select e1 cases default)
           n = SOME (e_select e1' cases default)
 Proof
 Induct_on ‘n’ >> (
@@ -2142,9 +2176,8 @@ QED
 
 Theorem e_multi_exec'_list'_LENGTH:
 !n ctx g_scope_list scope_list e_l e_l'.
-e_multi_exec'_list' ctx g_scope_list scope_list
-          e_l n =
-        SOME e_l' ==> LENGTH e_l = LENGTH e_l'
+e_multi_exec'_list' ctx g_scope_list scope_list e_l n = SOME e_l' ==>
+LENGTH e_l = LENGTH e_l'
 Proof
 Induct_on ‘n’ >> (
  rpt strip_tac >>
@@ -2184,7 +2217,9 @@ Theorem bigstep_e_struct_exec_sound_n:
 !ctx g_scope_list' scope_list n x_e_l e_l'.
 e_multi_exec'_list' ctx g_scope_list' scope_list (MAP SND x_e_l) n = SOME e_l' ==>
 x_e_l <> [] ==>
-if EVERY is_v e_l' then (e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list (e_struct x_e_l) (SUC n) = SOME (e_v $ v_struct (ZIP (MAP FST x_e_l,vl_of_el e_l')))) else (e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list (e_struct x_e_l) n = SOME (e_struct (ZIP (MAP FST x_e_l, e_l'))))
+if EVERY is_v e_l'
+then (e_multi_exec' (ctx:'a ctx) g_scope_list' scope_list (e_struct x_e_l) (SUC n) = SOME (e_v $ v_struct (ZIP (MAP FST x_e_l, vl_of_el e_l'))))
+else (e_multi_exec' ctx g_scope_list' scope_list (e_struct x_e_l) n = SOME (e_struct (ZIP (MAP FST x_e_l, e_l'))))
 Proof
 Induct_on ‘n’ >- (
  rpt strip_tac >>
@@ -2481,7 +2516,7 @@ Induct_on ‘t’ >- (
    gs[GSYM SUC_ADD_ONE] >>
    irule bigstep_e_acc_exec_sound_n_v >>
    gs[] >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    gs[] >>
@@ -2497,7 +2532,7 @@ Induct_on ‘t’ >- (
   gvs[] >>
   irule bigstep_e_acc_exec_sound_n_not_v >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   gs[]
@@ -2512,7 +2547,7 @@ Induct_on ‘t’ >- (
    irule bigstep_e_unop_exec_sound_n_v >>
    qexists_tac ‘e'’ >>
    gs[] >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    gs[] >>
@@ -2528,7 +2563,7 @@ Induct_on ‘t’ >- (
   gvs[] >>
   irule bigstep_e_unop_exec_sound_n_not_v >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   gs[]
@@ -2543,7 +2578,7 @@ Induct_on ‘t’ >- (
    irule bigstep_e_cast_exec_sound_n_v >>
    qexists_tac ‘e'’ >>
    gs[] >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
    res_tac >>
    gs[] >>
@@ -2559,7 +2594,7 @@ Induct_on ‘t’ >- (
   gvs[] >>
   irule bigstep_e_cast_exec_sound_n_not_v >>
   gs[] >>
-  PAT_X_ASSUM “!y. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  PAT_X_ASSUM “!y. _” (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
   res_tac >>
   gs[]
@@ -2575,9 +2610,9 @@ Induct_on ‘t’ >- (
    gs[GSYM SUC_ADD_ONE] >>
    irule bigstep_e_binop_exec_sound_n_first_shortcircuit >>
    gs[] >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2590,11 +2625,11 @@ Induct_on ‘t’ >- (
    ) >>
    irule bigstep_e_binop_exec_sound_n_both >>
    gs[] >>
-   qpat_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   qpat_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'3' - n'')’, ‘n''’] thm)) >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'3' - n'')’, ‘n''’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2607,11 +2642,11 @@ Induct_on ‘t’ >- (
    ) >>
    irule bigstep_e_binop_exec_sound_n_second >>
    gs[] >>
-   qpat_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   qpat_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n''’, ‘n''’] thm)) >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n''’, ‘n''’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2619,9 +2654,9 @@ Induct_on ‘t’ >- (
   ) >>
   (* Reduction of 1st operand only *)
   irule bigstep_e_binop_exec_sound_n_first >>
-  qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
-  qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
+  qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
   gs[] >>
   res_tac >>
   fs[]
@@ -2635,11 +2670,11 @@ Induct_on ‘t’ >- (
    ) >>
    irule bigstep_e_concat_exec_sound_n_both >>
    gs[] >>
-   qpat_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   qpat_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'3' - n'')’, ‘n''’] thm)) >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'3' - n'')’, ‘n''’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2652,11 +2687,11 @@ Induct_on ‘t’ >- (
    ) >>
    irule bigstep_e_concat_exec_sound_n_second >>
    gs[] >>
-   qpat_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x')’] thm)) >>
+   qpat_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x')’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n''’, ‘n''’] thm)) >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n''’, ‘n''’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2664,9 +2699,9 @@ Induct_on ‘t’ >- (
   ) >>
   (* Reduction of 1st operand *)
   irule bigstep_e_concat_exec_sound_n_first >>
-  qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
-  qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
+  qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
   gs[] >>
   res_tac >>
   fs[]
@@ -2679,9 +2714,9 @@ Induct_on ‘t’ >- (
    ) >>
    irule bigstep_e_slice_exec_sound_n_full >>
    gs[] >>
-   qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+   qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
    gs[e_size_def] >>
-   qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
+   qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n'' - n')’, ‘n'’] thm)) >>
    imp_res_tac bigstep_e_exec_incr >>
    gs[] >>
    res_tac >>
@@ -2689,9 +2724,9 @@ Induct_on ‘t’ >- (
   ) >>
   (* Reduction of operand to be sliced *)
   irule bigstep_e_slice_exec_sound_n_first >>
-  qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
-  qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
+  qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
   gs[] >>
   res_tac >>
   fs[]
@@ -2704,9 +2739,9 @@ Induct_on ‘t’ >- (
   (* select *)
   gvs[bigstep_e_exec_select_REWR] >>
   irule bigstep_e_select_exec_sound_n_first >>
-  qpat_x_assum ‘!y. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(INL x)’] thm)) >>
+  qpat_x_assum ‘!y. _’ (fn thm => assume_tac (Q.SPECL [‘(INL x)’] thm)) >>
   gs[e_size_def] >>
-  qpat_x_assum ‘!n''. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
+  qpat_x_assum ‘!n''. _’ (fn thm => assume_tac (Q.SPECL [‘(n + n') - n'’, ‘n'’] thm)) >>
   gs[] >>
   res_tac >>
   fs[]
@@ -2726,6 +2761,13 @@ Induct_on ‘t’ >- (
    gs[e_size_def] >>
    subgoal ‘e3_size (MAP SND (h::t)) < e1_size (h::t) + 1’ >- (
     gs[e3_e1_size]
+   ) >>
+   ‘e3_size (MAP SND t) + (e_size (SND h) + 1) <
+        list_size (pair_size (list_size char_size) e_size) t +
+        (pair_size (list_size char_size) e_size h + 2)’ by (
+    assume_tac $ Q.SPECL [‘t’] e3_size_list >>
+    Cases_on ‘h’ >>
+    gvs[]
    ) >>
    gs[e_size_def] >>
    qpat_x_assum ‘!n'' n'3'. _’ (fn thm => assume_tac (Q.SPECL [‘n'' - n'’, ‘n'’] thm)) >>
@@ -2754,6 +2796,11 @@ Induct_on ‘t’ >- (
   gs[e_size_def] >>
   subgoal ‘e3_size (MAP SND l) < e1_size l + 1’ >- (
    gs[e3_e1_size]
+  ) >>
+  ‘e3_size (MAP SND l) <
+    list_size (pair_size (list_size char_size) e_size) l + 1’ by (
+   assume_tac $ Q.SPECL [‘l’] e3_size_list >>
+   gvs[]
   ) >>
   gs[e_size_def] >>
   qpat_x_assum ‘!n'' n'3'. _’ (fn thm => assume_tac (Q.SPECL [‘n’, ‘n'’] thm)) >>
@@ -2803,7 +2850,7 @@ Cases_on ‘is_v x’ >> (
  Cases_on ‘x'0’ >>
  gs[] >>
  gvs[] >>
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
  gs[e_size_def] >>
  qpat_x_assum ‘!n'' n'3'. _’ (fn thm => assume_tac (Q.SPECL [‘x1 - n'’, ‘n'’] thm)) >>
  gs[] >>
@@ -2815,7 +2862,7 @@ Cases_on ‘is_v x’ >> (
  res_tac >>
  qpat_x_assum ‘!ctx. _’ (fn thm => assume_tac (Q.SPECL [‘ctx’] thm)) >>
  gs[] >>
- PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INR y)’] thm)) >>
+ PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INR y)’] thm)) >>
  gs[e_size_def] >>
  qpat_x_assum ‘!n'' n'3'. _’ (fn thm => assume_tac (Q.SPECL [‘n + n' - x1’, ‘x1’] thm)) >>
  gs[] >>
@@ -2838,7 +2885,7 @@ Cases_on ‘is_v x’ >> (
 ) >>
 gvs[] >>
 irule e_multi_exec'_list'_comp0 >>
-PAT_ASSUM “!y'. _” (fn thm => ASSUME_TAC (Q.SPECL [‘(INL h)’] thm)) >>
+PAT_ASSUM “!y'. _” (fn thm => assume_tac (Q.SPECL [‘(INL h)’] thm)) >>
 gs[e_size_def] >>
 qpat_x_assum ‘!n'' n'3'. _’ (fn thm => assume_tac (Q.SPECL [‘n’, ‘n'’] thm)) >>
 res_tac >>
@@ -2880,7 +2927,7 @@ QED
 Theorem bigstep_e_exec_sound_n_INR_zero:
 !e_l e_l' n n' scope_list g_scope_list' ctx.
 bigstep_e_exec (scope_list ++ g_scope_list') (INR e_l) n' = SOME (INR e_l', n'+n) ==>
- e_multi_exec'_list' (ctx:'a ctx) g_scope_list' scope_list e_l n = SOME e_l'
+e_multi_exec'_list' (ctx:'a ctx) g_scope_list' scope_list e_l n = SOME e_l'
 Proof
 rpt strip_tac >>
 irule bigstep_e_exec_sound_n_INR >>
@@ -3167,7 +3214,7 @@ QED
 Theorem bigstep_stmt_ass_exec_sound_n_not_v:
 !n ctx g_scope1 g_scope2 top_scope scope_list ascope funn l e e'.
 ~is_v e' ==>
-e_multi_exec' (ctx:'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) e n = SOME e' ==>
+e_multi_exec' ctx [g_scope1; g_scope2] (top_scope::scope_list) e n = SOME e' ==>
 stmt_multi_exec' (ctx:'a ctx)
  (ascope, [g_scope1; g_scope2],
   [(funn, [stmt_ass l e], (top_scope::scope_list))], status_running) n =
@@ -3273,7 +3320,7 @@ QED
 Theorem bigstep_stmt_ass_exec_sound_n_v:
 !n ctx g_scope1 g_scope2 top_scope scope_list ascope funn lval e e' scope_list'' g_scope1' g_scope2' scope_list'.
 is_v e' ==>
-e_multi_exec' (ctx:'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) e n = SOME e' ==>
+e_multi_exec' ctx [g_scope1; g_scope2] (top_scope::scope_list) e n = SOME e' ==>
 stmt_exec_ass lval e' ((top_scope::scope_list)++[g_scope1; g_scope2]) = SOME scope_list'' ==>
 separate scope_list'' = (SOME [g_scope1'; g_scope2'], SOME scope_list') ==>
 stmt_multi_exec' (ctx:'a ctx)
@@ -3512,7 +3559,7 @@ PairCases_on ‘x’ >>
 imp_res_tac stmt_multi_exec'_SOME_imp >>
 gs[] >>
 res_tac >>
-qpat_x_assum ‘!stmt'4'. _’ (fn thm => ASSUME_TAC (Q.SPEC ‘stmt_empty’ thm)) >>
+qpat_x_assum ‘!stmt'4'. _’ (fn thm => assume_tac (Q.SPEC ‘stmt_empty’ thm)) >>
 fs[is_empty_def, stmt_multi_exec'_check_state_def]
 QED
 
@@ -3741,7 +3788,7 @@ Cases_on ‘stmt_multi_exec'_check_state (x0,x1,x2,x3) x'’ >> (
 ) >>
 PairCases_on ‘x''’ >>
 gs[] >>
-qpat_x_assum ‘!ctx. _’ (fn thm => ASSUME_TAC (GSYM thm)) >>
+qpat_x_assum ‘!ctx. _’ (fn thm => assume_tac (GSYM thm)) >>
 gs[] >>
 Cases_on ‘stmt_multi_exec' ctx (x''0,x''1,x''2,x''3) m’ >> (
  gs[]
@@ -4087,8 +4134,8 @@ stmt_exec_ass lval e scope_lists = SOME scope_lists' ==>
 LENGTH scope_lists' = LENGTH scope_lists
 Proof
 rpt strip_tac >>
-Cases_on ‘e’ >> (
- gs[stmt_exec_ass_def]
+Cases_on ‘e’ >> Cases_on ‘lval’ >> (
+ gvs[stmt_exec_ass_def, assign_def, AllCaseEqs()]
 ) >>
 imp_res_tac assign_LENGTH
 QED
@@ -4822,8 +4869,8 @@ QED
 
 (* NOTE: This does not treat nested function calls *)
 Definition e_multi_exec'_aux_def:
- (e_multi_exec'_aux (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e 0 n_args = SOME e) /\
- (e_multi_exec'_aux (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e (SUC fuel) n_args =
+ (e_multi_exec'_aux (ext_map,func_map,b_func_map) g_scope_list scope_list e 0 n_args = SOME e) /\
+ (e_multi_exec'_aux (ext_map,func_map,b_func_map) g_scope_list scope_list e (SUC fuel) n_args =
   case e of
   | e_call funn e_l =>
    (case lookup_funn_sig funn func_map b_func_map ext_map of
@@ -4833,15 +4880,15 @@ Definition e_multi_exec'_aux_def:
      (case unred_arg_index (MAP SND x_d_l) e_l of
       | SOME i =>
        if i < n_args then
-       (case e_exec (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e of
+       (case e_exec (ext_map,func_map,b_func_map) g_scope_list scope_list e of
         | SOME (e', []) =>
-         e_multi_exec'_aux (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e' fuel n_args
+         e_multi_exec'_aux (ext_map,func_map,b_func_map) g_scope_list scope_list e' fuel n_args
         | _ => NONE)
-       else e_multi_exec'_aux (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e (SUC fuel) n_args
+       else e_multi_exec'_aux (ext_map,func_map,b_func_map) g_scope_list scope_list e (SUC fuel) n_args
       | NONE => SOME e
       )
     | NONE => NONE)
-  | _ => e_multi_exec' (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) g_scope_list scope_list e (SUC fuel)
+  | _ => e_multi_exec' (ext_map,func_map,b_func_map) g_scope_list scope_list e (SUC fuel)
  )
 Termination
 cheat
@@ -4884,7 +4931,7 @@ lookup_funn_sig funn func_map b_func_map ext_map = SOME x_d_l ==>
 oZIP (MAP SND x_d_l,e_l) = SOME d_e_l ==>
 bigstep_f_arg_exec_l_aux' (top_scope::(scope_list ++ [g_scope1; g_scope2])) d_e_l n m =
  SOME (e_l',n + n') ==>
-e_multi_exec'_aux ((apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' m = SOME (e_call funn e_l')
+e_multi_exec'_aux ((ext_map,func_map,b_func_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' m = SOME (e_call funn e_l')
 Proof
 rpt gen_tac >>
 rpt disch_tac >>
@@ -4939,7 +4986,7 @@ lookup_funn_sig funn func_map b_func_map ext_map = SOME x_d_l ==>
 oZIP (MAP SND x_d_l,e_l) = SOME d_e_l ==>
 bigstep_f_arg_exec_l (top_scope::(scope_list ++ [g_scope1; g_scope2])) d_e_l n =
  SOME (e_l',n + n') ==>
-e_multi_exec' ((apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' = SOME (e_call funn e_l')
+e_multi_exec' ((ext_map,func_map,b_func_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' = SOME (e_call funn e_l')
 Proof
 (*
 rpt gen_tac >>
@@ -4969,7 +5016,7 @@ lookup_funn_sig funn func_map b_func_map ext_map = SOME (ZIP (MAP FST $ MAP FST 
 bigstep_f_arg_exec_l (top_scope::(scope_list ++ [g_scope1; g_scope2])) d_e_l n =
  SOME (e_l',n + n') ==>
 
-e_multi_exec' ((apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' = SOME (e_call funn e_l')
+e_multi_exec' ((ext_map,func_map,b_func_map):'a ctx) [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (MAP SND d_e_l)) n' = SOME (e_call funn e_l')
 Proof
 Induct_on ‘n'’ >- (
  cheat
@@ -4982,10 +5029,10 @@ Cases_on ‘d_e_l’ >- (
 gvs[bigstep_f_arg_exec_l_def, bigstep_f_arg_exec'_def, AllCaseEqs()] >>
 ‘?h''.
   e_multi_exec'
-   ((apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map):'a ctx)
+   ((ext_map,func_map,b_func_map):'a ctx)
    [g_scope1; g_scope2] (top_scope::scope_list)
    (e_call funn (h''::MAP SND (t:(d#e) list))) n' = SOME (e_call funn (h'::MAP SND t)) /\
-    e_exec ((apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map):'a ctx)
+    e_exec ((ext_map,func_map,b_func_map):'a ctx)
    [g_scope1; g_scope2] (top_scope::scope_list) (e_call funn (SND (h:(d#e))::MAP SND t)) =
  SOME (e_call funn (h''::MAP SND t),[])’ suffices_by cheat >>
 SUBGOAL_THEN “(n:num) + SUC n' = n' + SUC n” (fn thm => FULL_SIMP_TAC empty_ss [Once thm]) >- (
@@ -5038,7 +5085,7 @@ rpt strip_tac >>
 gs[e_multi_exec'_def, stmt_multi_exec'_def] >>
 cheat
 (*
-Cases_on ‘e_multi_exec' (apply_table_f,ext_map,func_map,b_func_map,pars_map,tbl_map) [g_scope1; g_scope2] (top_scope::scope_list) e n’ >> (
+Cases_on ‘e_multi_exec' (ext_map,func_map,b_func_map) [g_scope1; g_scope2] (top_scope::scope_list) e n’ >> (
  gs[]
 ) >>
 Cases_on ‘e_exec ctx [g_scope1; g_scope2] (top_scope::scope_list) x’ >> (
@@ -5069,9 +5116,6 @@ Induct_on ‘stmt’ >- (
  (* empty *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -5239,9 +5283,6 @@ Induct_on ‘stmt’ >- (
  (* block *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -5453,9 +5494,6 @@ Induct_on ‘stmt’ >- (
  (* extern *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -5474,9 +5512,6 @@ Induct_on ‘stmt’ >- (
  (* empty *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -5679,9 +5714,6 @@ Induct_on ‘stmt’ >- (
  (* block *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -5900,9 +5932,6 @@ Induct_on ‘stmt’ >- (
  (* extern *)
  gs[stmt_multi_exec'_def, bigstep_stmt_exec_def, stmt_multi_exec'_check_state_def] >>
  rpt strip_tac >> (
-  subgoal ‘n = 0’ >- (
-   decide_tac
-  ) >>
   fs[separate_def, SUC_ADD_ONE, stmt_multi_exec'_def, stmt_multi_exec'_check_state_def] >>
   fs[GSYM SUC_ADD_ONE, oDROP_def, oTAKE_def, oDROP_APPEND, oTAKE_APPEND]
  )
@@ -6408,22 +6437,7 @@ Cases_on ‘bigstep_exec (SOME (func_map,b_func_map,ext_map)) ([g_scope1; g_scop
 PairCases_on ‘x'’ >>
 gs[] >>
 gvs[] >>
-gs[bigstep_exec_def] >>
-Cases_on ‘bigstep_stmt_exec (SOME (func_map,b_func_map,ext_map)) (h'2 ++ [g_scope1; g_scope2]) h' 0’ >> (
- gs[]
-) >>
-PairCases_on ‘x'’ >>
-gs[] >>
-Cases_on ‘separate x'1’ >> (
- gs[]
-) >>
-Cases_on ‘q’ >> (
- gs[]
-) >>
-Cases_on ‘r’ >> (
- gs[]
-) >>
-gvs[] >>
+gvs[bigstep_exec_def, AllCaseEqs()] >>
 (* Scope list non-empty should probably be added to in_local_fun' assumption, which can then be passed along to this theorem *)
 Cases_on ‘h'2’ >- (
  Cases_on ‘h'0’ >> (
@@ -6445,7 +6459,7 @@ strip_tac >- (
 ) >>
 Cases_on ‘t’ >> (
  gs[in_local_fun_def] >>
- qpat_x_assum ‘!tbl_map. _’ (fn thm => ASSUME_TAC (Q.SPECL [‘tbl_map’, ‘pars_map’, ‘funn’, ‘ascope’, ‘apply_table_f’] thm)) >>
+ qpat_x_assum ‘!tbl_map. _’ (fn thm => assume_tac (Q.SPECL [‘tbl_map’, ‘pars_map’, ‘funn’, ‘ascope’, ‘apply_table_f’] thm)) >>
  imp_res_tac stmt_multi_exec'_SOME_imp >>
  Cases_on ‘scope_list'’ >> (
   gs[]

--- a/hol/symb_exec/p4_convLib.sml
+++ b/hol/symb_exec/p4_convLib.sml
@@ -74,8 +74,7 @@ fun same_const_disj_list [] tm = K false tm
 
 (* Customized CBV_CONV for HOL4P4 evaluation *)
 local
- val list_of_thys = ["p4", "p4_aux", "p4_exec_sem",
-		     "p4_core", "p4_v1model", "p4_ebpf", "p4_vss", "p4_bigstep"]
+ val list_of_thys = ["p4_aux", "p4_core", "p4_v1model", "p4_ebpf", "p4_vss", "p4_bigstep"]
 
  fun filtered_thm_names name =
   (not $ String.isSuffix "_aux" name) andalso
@@ -253,6 +252,8 @@ val theories_with_convs = map (snd o fst) convs_in_hol4p4_compset
 in
  fun get_HOL4P4_CONV thms_to_add =
   let
+   val _ = add_thy_list list_of_thys the_compset
+
    val _ = computeLib.add_thms thms_to_add hol4p4_compset
   in
    computeLib.CBV_CONV hol4p4_compset

--- a/scripts/install_hol4.sh
+++ b/scripts/install_hol4.sh
@@ -8,7 +8,7 @@ cd ${INSTALL_DIR}
 if [ ! -e "HOL/bin/Holmake" ]; then
 	git clone https://github.com/HOL-Theorem-Prover/HOL.git
 	cd HOL
-	git checkout trindemossen-1
+	git checkout trindemossen-2
 	# Add compilation flags to avoid ISO C++17 incompatibility errors
 	# Note: Only done for amd64, doing this patch on aarch64 results in worse errors
 	if [[ $(dpkg --print-architecture) == "amd64" ]]

--- a/scripts/install_polyml.sh
+++ b/scripts/install_polyml.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${POLYML_VERSION}" ]]; then
-  POLYML_VERSION="5.9.1"
+  POLYML_VERSION="5.9.2"
 fi
 
 # If Poly/ML version is 5.7.1, use the one pre-packaged by Ubuntu instead


### PR DESCRIPTION
There's now a [new latest release of Poly/ML](https://github.com/polyml/polyml/releases/tag/v5.9.2), so bumping the version in the CI. The latest packaged version for Ubuntu is kept. I've also updated the repo for the `trindemossen-2` release of HOL4.