### PR TITLE
Make fixed-function blocks more powerful

### DIFF
--- a/hol/metatheory/p4_exec_sem_arch_soundnessScript.sml
+++ b/hol/metatheory/p4_exec_sem_arch_soundnessScript.sml
@@ -93,26 +93,12 @@ Cases_on `arch_frame_list` >> (
   ],
 
   (* fixed-function block *)
-  fs[arch_exec_def] >>
-  Cases_on `ALOOKUP ffblock_map s` >> (
-   fs[]
-  ) >>
-  Cases_on `x` >>
-  fs[] >>
-  Cases_on `f ascope` >> (
-   fs[]
-  ) >>
-  rw [] >>
+  gvs[arch_exec_def, AllCaseEqs()] >>
+  gvs[] >>
   metis_tac [(valOf o find_clause_arch_red) "arch_ffbl", clause_name_def],
 
   (* output *)
-  fs[arch_exec_def] >>
-  Cases_on `output_f (in_out_list',ascope)` >> (
-   fs[]
-  ) >>
-  PairCases_on `x` >>
-  fs[] >>
-  rw [] >>
+  gvs[arch_exec_def, AllCaseEqs()] >>
   metis_tac [(valOf o find_clause_arch_red) "arch_out", clause_name_def]
  ],
 

--- a/hol/p4Script.sml
+++ b/hol/p4Script.sml
@@ -201,8 +201,6 @@ Type s_t_list = ``:(s_t list)``
 
 Type ext_fun = ``:(('a # g_scope_list # scope_list) -> (('a # scope_list # status) option))``
 
-Type ff = ``:('a -> 'a option)``
-
 Type d_list = ``:(d list)``
 
 
@@ -229,6 +227,8 @@ Type func_map = ``:((string, (stmt # (string # d) list)) alist)``
 
 Type b_func_map = ``:((string, (stmt # (string # d) list)) alist)``
 
+Type in_out = ``:(bl # num)``
+
 Type ext_fun_map = ``:((string, ((string # d) list # 'a ext_fun)) alist)``
 
 
@@ -238,15 +238,19 @@ Type ext_map = ``:((string, ((((string # d) list # 'a ext_fun) option) # 'a ext_
 Type pars_map = ``:((string, stmt) alist)``
 
 Type tbl_map = ``:((string, ((mk list) # (x # e_list))) alist)``
+
+Type in_out_list = ``:(in_out list)``
+
+Type aenv = ``:(num # in_out_list # in_out_list # 'a)``
 val _ = Hol_datatype ` 
 pbl_type =  (* programmable block type *)
    pbl_type_parser
  | pbl_type_control
 `;
 
-Type in_out = ``:(bl # num)``
 
 
+Type ff = ``:(('a aenv) -> ('a aenv) option)``
 val _ = Hol_datatype ` 
 ffblock =  (* fixed-function block *)
    ffblock_ff of 'a ff
@@ -256,15 +260,13 @@ Type pblock = ``:(pbl_type # ((string # d) list) # b_func_map # t_scope # pars_m
 
 
 
-Type ffblock_map = ``:((string, 'a ffblock) alist)``
-
 Type pblock_map = ``:((string, pblock) alist)``
 
-Type in_out_list = ``:(in_out list)``
-
-Type random_oracle = ``:(num -> bool)``
+Type ffblock_map = ``:((string, 'a ffblock) alist)``
 
 Type pblock_list = ``:(pblock list)``
+
+Type random_oracle = ``:(num -> bool)``
 val _ = Hol_datatype ` 
 arch_block =  (* architectural block *)
    arch_block_inp
@@ -308,8 +310,6 @@ Type frame = ``:(funn # stmt_stack # scope_list)``
 Type frame_list = ``:(frame list)``
 
 Type state = ``:('a # g_scope_list # frame_list # status)``
-
-Type aenv = ``:(num # in_out_list # in_out_list # 'a)``
 
 
 val _ = Hol_datatype ` 
@@ -2697,13 +2697,13 @@ Inductive arch_sem:
  ==> 
 ( ( arch_red  ( ab_list ,  pblock_map ,  ffblock_map ,  input_f ,  output_f ,  copyin_pbl ,  copyout_pbl ,  apply_table_f ,  ext_map ,  func_map ,  get_oracle_index  ,  set_oracle_index  ,  random_oracle )   (  (  i  ,  in_out_list ,  in_out_list' ,  ascope )  ,  g_scope_list ,  arch_frame_list_empty ,  status_running )   (  (  i  ,  in_out_list ,  in_out_list' ,  set_oracle_index   i_opt'   ascope )  ,  g_scope_list''' ,  (arch_frame_list_regular  ([   ( (funn_name f)  ,   ( ([(stmt)]) )   ,   ( ([( [] )]) )  )   ]) ) ,  status_running )  )))
 
-[arch_ffbl:] (! (ab_list:ab_list) (pblock_map:pblock_map) (ffblock_map:'a ffblock_map) (input_f:'a input_f) (output_f:'a output_f) (copyin_pbl:'a copyin_pbl) (copyout_pbl:'a copyout_pbl) (apply_table_f:'a apply_table_f) (ext_map:'a ext_map) (func_map:func_map) (get_oracle_index:'a get_oracle_index) (set_oracle_index:'a set_oracle_index) (random_oracle:random_oracle) (i:i) (in_out_list:in_out_list) (in_out_list':in_out_list) (ascope:'a) (g_scope_list:g_scope_list) (ascope':'a) (x:x) (ff:'a ff) .
+[arch_ffbl:] (! (ab_list:ab_list) (pblock_map:pblock_map) (ffblock_map:'a ffblock_map) (input_f:'a input_f) (output_f:'a output_f) (copyin_pbl:'a copyin_pbl) (copyout_pbl:'a copyout_pbl) (apply_table_f:'a apply_table_f) (ext_map:'a ext_map) (func_map:func_map) (get_oracle_index:'a get_oracle_index) (set_oracle_index:'a set_oracle_index) (random_oracle:random_oracle) (i:i) (in_out_list:in_out_list) (in_out_list':in_out_list) (ascope:'a) (g_scope_list:g_scope_list) (i':i) (in_out_list'':in_out_list) (in_out_list''':in_out_list) (ascope':'a) (x:x) (ff:'a ff) .
 (clause_name "arch_ffbl") /\
 (( (  (arch_block_ffbl x)  = EL  i   ab_list  ) ) /\
 ( (ALOOKUP  ffblock_map   x  = SOME  (ffblock_ff ff) ) ) /\
-( (SOME  ascope'  =  ff  ( ascope ) ) ))
+( (SOME   (  i'  ,  in_out_list'' ,  in_out_list''' ,  ascope' )   =  ff  (  (  i  ,  in_out_list ,  in_out_list' ,  ascope )  ) ) ))
  ==> 
-( ( arch_red  ( ab_list ,  pblock_map ,  ffblock_map ,  input_f ,  output_f ,  copyin_pbl ,  copyout_pbl ,  apply_table_f ,  ext_map ,  func_map ,  get_oracle_index  ,  set_oracle_index  ,  random_oracle )   (  (  i  ,  in_out_list ,  in_out_list' ,  ascope )  ,  g_scope_list ,  arch_frame_list_empty ,  status_running )   (  (  (   i   +   1   )  ,  in_out_list ,  in_out_list' ,  ascope' )  ,  g_scope_list ,  arch_frame_list_empty ,  status_running )  )))
+( ( arch_red  ( ab_list ,  pblock_map ,  ffblock_map ,  input_f ,  output_f ,  copyin_pbl ,  copyout_pbl ,  apply_table_f ,  ext_map ,  func_map ,  get_oracle_index  ,  set_oracle_index  ,  random_oracle )   (  (  i  ,  in_out_list ,  in_out_list' ,  ascope )  ,  g_scope_list ,  arch_frame_list_empty ,  status_running )   (  (  i'  ,  in_out_list'' ,  in_out_list''' ,  ascope' )  ,  g_scope_list ,  arch_frame_list_empty ,  status_running )  )))
 
 [arch_out:] (! (ab_list:ab_list) (pblock_map:pblock_map) (ffblock_map:'a ffblock_map) (input_f:'a input_f) (output_f:'a output_f) (copyin_pbl:'a copyin_pbl) (copyout_pbl:'a copyout_pbl) (apply_table_f:'a apply_table_f) (ext_map:'a ext_map) (func_map:func_map) (get_oracle_index:'a get_oracle_index) (set_oracle_index:'a set_oracle_index) (random_oracle:random_oracle) (i:i) (in_out_list:in_out_list) (in_out_list':in_out_list) (ascope:'a) (g_scope_list:g_scope_list) (in_out_list'':in_out_list) (ascope':'a) .
 (clause_name "arch_out") /\

--- a/hol/p4_exec_semScript.sml
+++ b/hol/p4_exec_semScript.sml
@@ -2204,9 +2204,9 @@ Definition arch_exec_def:
    | (arch_block_ffbl x) =>
     (case ALOOKUP ffblock_map x of
      | SOME (ffblock_ff ff) =>
-      (case ff scope of
-       | SOME scope' =>
-        SOME ((i+1, in_out_list, in_out_list', scope'), g_scope_list, arch_frame_list_empty, status_running)
+      (case ff (i, in_out_list, in_out_list', scope) of
+       | SOME (i', in_out_list'', in_out_list''', scope') =>
+        SOME ((i', in_out_list'', in_out_list''', scope'), g_scope_list, arch_frame_list_empty, status_running)
        | NONE => NONE)
      | NONE => NONE)
    (* out *)

--- a/hol/p4_v1modelScript.sml
+++ b/hol/p4_v1modelScript.sml
@@ -662,13 +662,13 @@ End
  * then resets the shared packet "b" (TODO: Fix that hack) and saves its content in "b_temp" *)
 (* TODO: Note that this also resets parseError to 0 *)
 Definition v1model_postparser_def:
- v1model_postparser ((counter, ext_obj_map, v_map, ctrl, oracle_index):v1model_ascope) =
+ v1model_postparser ((i, io_list, io_list', (counter, ext_obj_map, v_map, ctrl, oracle_index)):v1model_ascope aenv) =
   (case ALOOKUP v_map "b" of
-   | SOME (v_ext_ref i) =>
-    (case ALOOKUP ext_obj_map i of
+   | SOME (v_ext_ref j) =>
+    (case ALOOKUP ext_obj_map j of
      | SOME (INL (core_v_ext_packet bl)) =>
       (case ALOOKUP v_map "b_temp" of
-       | SOME (v_ext_ref i') =>
+       | SOME (v_ext_ref j') =>
         (case ALOOKUP v_map "parsedHdr" of
          | SOME v =>
           let v_map' = AUPDATE v_map ("hdr", v) in
@@ -679,8 +679,8 @@ Definition v1model_postparser_def:
                (case scope_to_vmap v_map_scope of
                 | SOME v_map'' =>
                  let v_map''' = AUPDATE v_map'' ("parseError", v_bit (fixwidth 32 (n2v 0), 32)) in
-                 let (counter', ext_obj_map', v_map'''', ctrl', oracle_index') = (v1model_ascope_update (counter, ext_obj_map, v_map''', ctrl, oracle_index) i' (INL (core_v_ext_packet bl))) in
-   SOME (v1model_ascope_update (counter', ext_obj_map', v_map'''', ctrl', oracle_index') i (INL (core_v_ext_packet [])))
+                 let (counter', ext_obj_map', v_map'''', ctrl', oracle_index') = (v1model_ascope_update (counter, ext_obj_map, v_map''', ctrl, oracle_index) j' (INL (core_v_ext_packet bl))) in
+   SOME (i+1, io_list, io_list', (v1model_ascope_update (counter', ext_obj_map', v_map'''', ctrl', oracle_index') j (INL (core_v_ext_packet []))))
                 | NONE => NONE)
               | _ => NONE)
             | NONE => NONE)

--- a/hol/p4_vssScript.sml
+++ b/hol/p4_vssScript.sml
@@ -5,6 +5,8 @@ val _ = new_theory "p4_vss";
 open ottLib;
 open p4Theory p4_auxTheory p4_coreTheory;
 
+intLib.deprecate_int();
+
 Datatype:
  vss_v_ext =
    vss_v_ext_ipv4_checksum (word16 list)
@@ -224,20 +226,20 @@ Definition vss_copyout_pbl_def:
 End
 
 Definition vss_parser_runtime_def:
- vss_parser_runtime ((counter, ext_obj_map, v_map, ctrl, oracle_index):vss_ascope) =
+ vss_parser_runtime (i, io_list, io_list', (counter, ext_obj_map, v_map, ctrl, oracle_index):vss_ascope) =
   (case ALOOKUP v_map "parsedHeaders" of
    | SOME (v_struct hdrs) =>
     let v_map' = AUPDATE v_map ("headers", v_struct hdrs) in
-     SOME (counter, ext_obj_map, v_map', ctrl, oracle_index)
+     SOME (i+1, io_list, io_list', (counter, ext_obj_map, v_map', ctrl, oracle_index))
    | _ => NONE)
 End
 
 Definition vss_pre_deparser_def:
- vss_pre_deparser ((counter, ext_obj_map, v_map, ctrl, oracle_index):vss_ascope) =
+ vss_pre_deparser (i, io_list, io_list', (counter, ext_obj_map, v_map, ctrl, oracle_index):vss_ascope) =
   (case ALOOKUP v_map "headers" of
    | SOME (v_struct hdrs) =>
     let v_map' = AUPDATE v_map ("outputHeaders", v_struct hdrs) in
-     SOME (counter, ext_obj_map, v_map', ctrl, oracle_index)
+     SOME (i+1, io_list, io_list', (counter, ext_obj_map, v_map', ctrl, oracle_index))
    | _ => NONE)
 End
 

--- a/hol/polymorphise_p4Script.py
+++ b/hol/polymorphise_p4Script.py
@@ -16,6 +16,8 @@ od_hacks = OrderedDict([("Type ascope = ``:('a)``", ""), #Delete this type abbre
                         #TODO: Handled below?
                         ("Type actx = ``:(ab_list # pblock_map # ffblock_map # input_f # output_f # copyin_pbl # copyout_pbl # apply_table_f # ext_map # func_map # get_oracle_index # set_oracle_index # random_oracle)``",
                          "Type actx = ``:(ab_list # pblock_map # 'a ffblock_map # 'a input_f # 'a output_f # 'a copyin_pbl # 'a copyout_pbl # 'a apply_table_f # 'a ext_map # func_map # 'a get_oracle_index # 'a set_oracle_index # random_oracle)``"),
+                        ("Type ff = ``:(aenv -> aenv option)``",
+                         "Type ff = ``:(('a aenv) -> ('a aenv) option)``"),
                         ("Type astate = ``:(aenv # g_scope_list # arch_frame_list # status)``",
                          "Type astate = ``:('a aenv # g_scope_list # arch_frame_list # status)``"),
                         ("Type ext_fun_map = ``:((string, ((string # d) list # ext_fun)) alist)``",

--- a/ott/p4.ott
+++ b/ott/p4.ott
@@ -540,10 +540,6 @@ d {{ tex d }} :: d_ ::=
 | none :: :: none
   {{ tex \circ }}
 
-%The "fixed function" of a fixed-function block
-ff {{ tex { \mathit{ff} } }} :: ff_ ::=
-{{ hol (ascope_ty -> ascope_ty option) }}
-
 d_list :: d_list_ ::=
 {{ com list of directions }}
 {{ hol (d list) }}
@@ -720,6 +716,12 @@ ext_fun_map {{ tex X_{ \mathrm{obj} } }} :: ext_fun_map_ ::=
 {{ com extern function map }}
 {{ hol ((string, ((string # d) list # ext_fun)) alist) }}
 
+in_out :: in_out_ ::=
+{{ com input and output }}
+{{ hol (bl # num) }}
+| packet bl i :: M :: packet
+  {{ hol ( [[bl]] , [[i]] ) }}
+
 %Fence between ext_fun_map and ext_map
 embed
 {{ hol
@@ -741,21 +743,32 @@ tbl_map {{ tex { \mathit{Tb} } }} :: tbl_map_ ::=
 | ( tbl_map ) :: S :: paren
   {{ hol ([[tbl_map]]) }}
 
-
 pars_map {{ tex P }} :: pars_map_ ::=
 {{ com parser state map }}
 {{ hol ((string, stmt) alist) }}
 
-in_out :: in_out_ ::=
-{{ com input and output }}
-{{ hol (bl # num) }}
-| packet bl i :: M :: packet
-  {{ hol ( [[bl]] , [[i]] ) }}
+in_out_list {{ tex \overline{ \mathit{io} } }} :: in_out_list_ ::=
+{{ com list of input and output }}
+{{ hol (in_out list) }}
 
 pbl_type :: pbl_type_ ::=
 {{ com programmable block type }}
 | parser :: :: parser
 | control :: :: control
+
+aenv {{ tex { \mathit{env}_\mathit{A} } }} :: aenv_ ::=
+{{ com architectural environment }}
+{{ hol (num # in_out_list # in_out_list # ascope_ty) }}
+| empty :: M :: empty
+  {{ com empty architectural environment }}
+  {{ hol (0, [], [], []) }}
+| ( num_exp , in_out_list , in_out_list' , ascope ) :: M :: tup
+  {{ com tuple }}
+  {{ hol ([[num_exp]], [[in_out_list]], [[in_out_list']], [[ascope]]) }}
+%TODO: Allow set_oracle index here or in ascope definition?
+| ( num_exp , in_out_list , in_out_list' , set_oracle_index i_opt ascope ) :: M :: set_oracle_index
+  {{ com tuple }}
+  {{ hol ([[num_exp]], [[in_out_list]], [[in_out_list']], [[set_oracle_index]] [[i_opt]] [[ascope]]) }}
 
 %Fence between pbl_type and pblock
 embed
@@ -763,6 +776,10 @@ embed
 
 }}
 grammar
+
+%The "fixed function" of a fixed-function block
+ff {{ tex { \mathit{ff} } }} :: ff_ ::=
+{{ hol (aenv -> aenv option) }}
 
 pblock {{ tex { \mathit{pblock} } }} :: pblock_ ::=
 {{ com programmable block }}
@@ -798,10 +815,6 @@ pblock_map {{ tex B_p }} :: pblock_map_ ::=
 ffblock_map {{ tex B_{ \mathrm{ff} } }} :: ffblock_map_ ::=
 {{ com fixed-function block map }}
 {{ hol ((string, ffblock) alist) }}
-
-in_out_list {{ tex \overline{ \mathit{io} } }} :: in_out_list_ ::=
-{{ com list of input and output }}
-{{ hol (in_out list) }}
 
 %This function takes an index and returns a Boolean
 %Effectively, each call with a new index yields a new random bit

--- a/ott/p4_sem.ott
+++ b/ott/p4_sem.ott
@@ -73,21 +73,6 @@ state {{ tex s }} :: state_ ::=
 | ( set_oracle_index i_opt ascope , g_scope_list , frame_list , status ) :: M :: set_oracle_index
 {{ hol (set_oracle_index [[i_opt]] [[ascope]], [[g_scope_list]], [[frame_list]], [[status]]) }}
 
-aenv {{ tex { \mathit{env}_\mathit{A} } }} :: aenv_ ::=
-{{ com architectural environment }}
-{{ hol (num # in_out_list # in_out_list # ascope_ty) }}
-| empty :: M :: empty
-  {{ com empty architectural environment }}
-  {{ hol (0, [], [], []) }}
-| ( num_exp , in_out_list , in_out_list' , ascope ) :: M :: tup
-  {{ com tuple }}
-  {{ hol ([[num_exp]], [[in_out_list]], [[in_out_list']], [[ascope]]) }}
-%TODO: Allow set_oracle index here or in ascope definition?
-| ( num_exp , in_out_list , in_out_list' , set_oracle_index i_opt ascope ) :: M :: set_oracle_index
-  {{ com tuple }}
-  {{ hol ([[num_exp]], [[in_out_list]], [[in_out_list']], [[set_oracle_index]] [[i_opt]] [[ascope]]) }}
-
-%Fence so that ott does not re-order aenv and astate
 embed
 {{ hol
 
@@ -464,9 +449,9 @@ formula :: formula_ ::=
 | arch_block = ab_list [ i ] :: M :: ab_index
   {{ com ab at index i }}
   {{ hol ( [[arch_block]] = EL [[i]] [[ab_list]] ) }}
-| ascope' = ff ( ascope ) :: M :: app_ff
+| aenv' = ff ( aenv ) :: M :: app_ff
   {{ com apply fixed function }}
-  {{ hol (SOME [[ascope']] = [[ff]] ([[ascope]]) ) }}
+  {{ hol (SOME [[aenv']] = [[ff]] ([[aenv]]) ) }}
 | ( in_out_list' , ascope' ) = input_f ( in_out_list , ascope ) :: M :: input_f
   {{ com apply input function }}
   {{ hol ( SOME ( [[in_out_list']] , [[ascope']] ) = [[input_f]] ( [[in_out_list]] , [[ascope]] ) ) }}
@@ -3193,9 +3178,9 @@ by
 
   ffbl x = ab_list [ i ]
   ff = ffblock_map ( x )
-  ascope' = ff ( ascope )
+  ( i' , in_out_list'' , in_out_list''' , ascope' ) = ff ( ( i , in_out_list , in_out_list' , ascope ) )
   ----------------------------------- :: ffbl
-  ( ab_list , pblock_map , ffblock_map , input_f , output_f , copyin_pbl , copyout_pbl , apply_table_f , ext_map , func_map , get_oracle_index , set_oracle_index , random_oracle ) ( ( i , in_out_list , in_out_list' , ascope ) , g_scope_list , arch_frame_list_empty , Running ) -'> ( ( i + 1 , in_out_list , in_out_list' , ascope' ) , g_scope_list , arch_frame_list_empty , Running )
+  ( ab_list , pblock_map , ffblock_map , input_f , output_f , copyin_pbl , copyout_pbl , apply_table_f , ext_map , func_map , get_oracle_index , set_oracle_index , random_oracle ) ( ( i , in_out_list , in_out_list' , ascope ) , g_scope_list , arch_frame_list_empty , Running ) -'> ( ( i' , in_out_list'' , in_out_list''' , ascope' ) , g_scope_list , arch_frame_list_empty , Running )
 
 %Note that this always sets index to 0. This could be done conditionally, if it would not be ideal
 %to have the final state have index 0.


### PR DESCRIPTION
One way to implement support for non-linear pipeline flows is to allow fixed-function blocks to jump to arbitrary other blocks, instead of just to the next block. This allows to model certain more complex flows found in the PSA architecture: ingress and egress cloning, multicast, ingress dropping and ingress resubmission.

Concretely, this is implemented by making ffblocks operate on `aenv` instead of just `ascope`.