### PR TITLE
Update Ubuntu version, fix OCaml compiler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL description="This is a docker image for HOL4P4"
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS="yes"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,9 +9,9 @@ Then, build and run the Docker image (in the root directory of this repo contain
 	docker build -t hol4p4 .
 	docker run -it hol4p4
 
-# Manual Installation for Ubuntu 22.04
+# Manual Installation for Ubuntu 24.04
 
-This guide assumes a fresh install of Ubuntu 22.04.
+This guide assumes a fresh install of Ubuntu 24.04.
 
 ## Dependencies
 
@@ -72,8 +72,9 @@ First, navigate to the directory where you want to put the source code of Poly/M
 4. Install OPAM
 
 		sudo apt-get install opam
-		opam init
+		opam init --compiler=4.13.1
 	
+	Version 4.13.1 of the OCaml compiler is used to enable compilation of petr4.
 	When prompted, make a choice whether to let OPAM set environment variables or not. Then run
 
 		eval $(opam env --switch=default)
@@ -120,7 +121,7 @@ You can also use `make docs/semantics/main.pdf` to build the documentation of th
 
 The same tools used to edit HOL4 theories and run the HOL4 REPL can also be used for this project. Specifically, we recommend Emacs - a full guide for using HOL4 with Emacs can be found [here](https://hol-theorem-prover.org/HOL-interaction.pdf).
 
-# Automatic installation scripts for Ubuntu 22.04
+# Automatic installation scripts for Ubuntu 24.04
 
 The `scripts` directory contains installation scripts. These may be run when installing HOL4P4 e.g. on a fresh virtual machine by
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-#This script is used as a quick-and-dirty way to install all prerequisites and compile HOL4P4 on a fresh Ubuntu 22.04 installation.
+#This script is used as a quick-and-dirty way to install all prerequisites and compile HOL4P4 on a fresh Ubuntu 24.04 installation.
 
 sudo apt-get update
-#TODO Remove git when no longer needed
 sudo apt-get install -y build-essential git python3 file zlib1g-dev libbz2-dev liblzma-dev wget
 
 #Path to where this file is located
@@ -19,7 +18,6 @@ FILEPATH=$(dirname "$FILE")
 
 . ${FILEPATH}/install_hol4.sh ${PWD} ${PWD}
 
-#TODO Tested with OCaml 4.13.1 - fix version?
 . ${FILEPATH}/install_opam.sh
 
 . ${FILEPATH}/install_ott.sh

--- a/scripts/install_opam.sh
+++ b/scripts/install_opam.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 sudo apt-get install -y opam
-opam init --auto-setup --yes --disable-sandboxing
+opam init --auto-setup --yes --disable-sandboxing --compiler=4.13.1
 eval $(opam env --switch=default)

--- a/scripts/install_petr4.sh
+++ b/scripts/install_petr4.sh
@@ -10,7 +10,6 @@ cd petr4
 git checkout 0.1.2
 
 #Includes
-#TODO: VSS also?
 mkdir -p ${INSTALL_DIR}/hol/p4_from_json/p4include;
 cp examples/core.p4 ${INSTALL_DIR}/hol/p4_from_json/p4include/
 cp examples/ebpf_model.p4 ${INSTALL_DIR}/hol/p4_from_json/p4include/


### PR DESCRIPTION
For some time, the compilation of petr4 has been silently failing in the CI.

This sorts petr4 compilation by fixing the compiler version to the last known compatible version. A longer-term solution might be to perform some basic janitorial duties in the petr4 repo.

Also, it's time to bump the Ubuntu version (CI uses `ubuntu-latest`, most users are probably on Ubuntu 24 by now).